### PR TITLE
Build a CI environment in order to allow automated testing

### DIFF
--- a/.tools/ci/after_failure.sh
+++ b/.tools/ci/after_failure.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# As the filename suggests this is executed on build success.
+#

--- a/.tools/ci/after_script.sh
+++ b/.tools/ci/after_script.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# As the filename suggests this is executed on build success.
+#

--- a/.tools/ci/after_success.sh
+++ b/.tools/ci/after_success.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# As the filename suggests this is executed on build success.
+#

--- a/.tools/ci/before_install.sh
+++ b/.tools/ci/before_install.sh
@@ -1,0 +1,25 @@
+#!/bin/sh 
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# As the filename suggests this is executed on build success.
+#
+
+set -x
+
+echo "USE mysql;\nUPDATE user SET password=PASSWORD('password') WHERE user='root';\nFLUSH PRIVILEGES;\n" | mysql -u root
+sh '.tools/ci/cloudstack-simulator.sh'

--- a/.tools/ci/before_script.sh
+++ b/.tools/ci/before_script.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# As the filename suggests this is executed on build success.
+#

--- a/.tools/ci/cloudstack-simulator.sh
+++ b/.tools/ci/cloudstack-simulator.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+
+set -x
+
+MYSQL_ROOT_PASSWORD="password"
+
+MAVEN_REPO="http://repo1.maven.org/maven2"
+
+JETTY_VERSION="9.2.6.v20141205"
+MYSQL_CONNECTOR_VERSION="5.1.34"
+
+CLOUDSTACK_WAR_URL="http://jenkins.buildacloud.org/view/4.3/job/cloudstack-4.3-maven-build-noredist/lastSuccessfulBuild/artifact/client/target/cloud-client-ui-4.3.2.war"
+CLOUDSTACK_REPO_URL="https://github.com/apache/cloudstack/tags/4.3.2"
+
+
+
+get_jar() {
+	if [ -z "$(find "$HOME/.m2" -name "$2*.jar")" ]; then
+		mvn -DrepoUrl="$MAVEN_REPO" -DgroupId="$1" -DartifactId="$2" -Dversion="$3" dependency:get >/dev/null 2>/dev/null
+	fi
+	if [ -n "$(find "$HOME/.m2" -name "$2*.jar")" ]; then
+		find "$HOME/.m2" -name "$2*.jar" -print -quit
+	else
+		# Couldn't install jetty-runner
+		return 1
+	fi
+}
+
+
+jetty_runner_path=$(get_jar 'org.eclipse.jetty' 'jetty-runner' "$JETTY_VERSION")
+mysql_connector_path=$(get_jar 'mysql' 'mysql-connector-java' "$MYSQL_CONNECTOR_VERSION")
+
+mkdir -p database-imports/
+
+if [ ! -f 'cloudstack.war' ]; then
+	wget -O 'cloudstack.war' "$CLOUDSTACK_WAR_URL"
+	jar -xvf cloudstack.war
+	svn export --force "$CLOUDSTACK_REPO_URL/utils/conf/db.properties"
+	svn export --force "$CLOUDSTACK_REPO_URL/developer/developer-prefill.sql" "database-imports/developer-prefill.sql"
+	svn export --force "$CLOUDSTACK_REPO_URL/setup/db" "database-imports"
+	rm -rf 'db'; mv 'database-imports/db' 'db'
+fi
+
+mkdir -p lib
+cp "$mysql_connector_path" lib/
+
+classpath=$(find . -name '*.jar' -print0 | sed -e 's/\.\//:/g')
+java -cp ".$classpath" com.cloud.upgrade.DatabaseCreator db.properties database-imports/create-schema.sql database-imports/create-schema-premium.sql database-imports/templates.sql database-imports/developer-prefill.sql com.cloud.upgrade.DatabaseUpgradeChecker --database=cloud,usage,awsapi --rootpassword="$MYSQL_ROOT_PASSWORD"
+java -cp ".$classpath" com.cloud.upgrade.DatabaseCreator db.properties database-imports/create-schema-simulator.sql database-imports/templates.simulator.sql database-imports/hypervisor_capabilities.simulator.sql com.cloud.upgrade.DatabaseUpgradeChecker --database=simulator --rootpassword="$MYSQL_ROOT_PASSWORD"
+java -Xmx512m -XX:MaxPermSize=512m -jar "$jetty_runner_path" --path /client 'cloudstack.war' --lib 'lib/'

--- a/.tools/ci/cloudstack-simulator.sh
+++ b/.tools/ci/cloudstack-simulator.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
-
 set -x
+
+mkdir ./.tools/tmp
+cd ./.tools/tmp
 
 MYSQL_ROOT_PASSWORD="password"
 
@@ -21,7 +23,7 @@ get_jar() {
 	if [ -n "$(find "$HOME/.m2" -name "$2*.jar")" ]; then
 		find "$HOME/.m2" -name "$2*.jar" -print -quit
 	else
-		# Couldn't install jetty-runner
+		# Couldn't install jar
 		return 1
 	fi
 }
@@ -34,7 +36,7 @@ mkdir -p database-imports/
 
 if [ ! -f 'cloudstack.war' ]; then
 	wget -O 'cloudstack.war' "$CLOUDSTACK_WAR_URL"
-	jar -xvf cloudstack.war
+	unzip cloudstack.war -d exploded_cloudstack_war
 	svn export --force "$CLOUDSTACK_REPO_URL/utils/conf/db.properties"
 	svn export --force "$CLOUDSTACK_REPO_URL/developer/developer-prefill.sql" "database-imports/developer-prefill.sql"
 	svn export --force "$CLOUDSTACK_REPO_URL/setup/db" "database-imports"

--- a/.tools/ci/install.sh
+++ b/.tools/ci/install.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# As the filename suggests this is executed on build success.
+#

--- a/.tools/ci/script.sh
+++ b/.tools/ci/script.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# As the filename suggests this is executed on build success.
+#

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+language: java
+notifications:
+  email: false
+before_install: ./.tools/ci/before_install.sh
+install: ./.tools/ci/install.sh
+before_script: ./.tools/ci/before_script.sh
+script: ./.tools/ci/script.sh
+after_success: ./.tools/ci/after_success.sh
+after_failure: ./.tools/ci/after_failure.sh
+after_script: ./.tools/ci/after_script.sh


### PR DESCRIPTION
Hi All,

I'm creating this pull request to get some assistance with finishing an idea.

I thought it would be neat if we could bring up Apache Cloudstack on TravisCI under simulator mode and execute some cloudmonkey scripts to do the configuration and verify the responses. 

The pull request at the moment causes TravisCI to bring up an environment with:
 - Mysql installed with password "password".
 - Cloudstack 4.3.2 running on port 8080 with the simulator sql stuff imported into the db. At the moment I have it blocking on this, in the future this would be a background task.

Any assistance with the following is welcome:
 - cloudmonkey scripts to configure cloudstack in simulator mode. (Just like marvin does)
 - the output generated by cloudmonkey should be verified in some way. Perhaps just simple greping for now?
 - we can finish at this point or introduce some other scripts to generate more cloudmonkey outputs that we can verify. 


Thoughts? Ideas? Shoot downs?