### PR TITLE
Fix KeyError: 'TERM' when no TERM exist

### DIFF
--- a/cloudmonkey/cloudmonkey.py
+++ b/cloudmonkey/cloudmonkey.py
@@ -57,7 +57,8 @@ except ImportError:
 normal_readline = True
 # Fix terminal env before importing readline
 # Without it, char ESC[?1034h gets printed in output
-if os.environ['TERM'].startswith('xterm'):
+# There is not TERM variable in some environment such as Docker.
+if not 'TERM' in os.environ or os.environ['TERM'].startswith('xterm'):
     os.environ['TERM'] = 'vt100'
 try:
     import readline


### PR DESCRIPTION
There is no TERM environment variable if CLI is called from python script in docker container.
It cause ```KeyError: 'TERM'``` because it does not check an environment variable existence.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>
Signed-off-by: Hiroshi Miura <miurahr@nttdata.co.jp>