### PR TITLE
In the specific case of a "create networkoffering" with no services, …

### DIFF
--- a/cloudmonkey/requester.py
+++ b/cloudmonkey/requester.py
@@ -183,7 +183,7 @@ def make_request(command, args, logger, url, credentials, expires,
         if isinstance(value, unicode):
             value = value.encode("utf-8")
         args[key] = value
-        if not key or not value:
+        if not key:
             args.pop(key)
 
     # try to use the apikey/secretkey method by default


### PR DESCRIPTION
…the parameter 'supportedservices' gets stripped off because it's empty. However, the API requires it as mandatatory - and yes, the UI allows you to create a n.o. with no services.