### PR TITLE
Import error when running cloudmonkey

### DIFF
--- a/cloudmonkey/requester.py
+++ b/cloudmonkey/requester.py
@@ -28,20 +28,13 @@ try:
     import sys
     import time
     import urllib
-    import urllib2
 
     from datetime import datetime, timedelta
     from requests_toolbelt import SSLAdapter
-    from urllib2 import HTTPError, URLError
 except ImportError, e:
     print "Import error in %s : %s" % (__name__, e)
     import sys
     sys.exit()
-
-
-# Disable HTTPS verification warnings.
-from requests.packages import urllib3
-urllib3.disable_warnings()
 
 
 def logger_debug(logger, message):


### PR DESCRIPTION
The cloudmonkey install from pip does not run and gives an import error because the latest `requests` package dropped the `requests.packages.urllib3`. I am removing an import which tries to access that. Note that even after removing that line, I still get import errors because `requests_toolbelt` uses  `requests.packages.urllib3`. They have fixed it in their master but haven't yet pushed onto PyPi. I have also opened a bug with them for the same. 