### PR TITLE
Update requester.py

### DIFF
--- a/cloudmonkey/requester.py
+++ b/cloudmonkey/requester.py
@@ -202,7 +202,7 @@ def make_request(command, args, logger, url, credentials, expires,
         hash_str = "&".join(
             ["=".join(
                 [r[0].lower(),
-                 urllib.quote_plus(str(r[1])).lower()
+                 urllib.quote_plus(str(r[1]), safe="*").lower()
                  .replace("+", "%20").replace("%3A", ":")]
             ) for r in request]
         )


### PR DESCRIPTION
urllib.quote_plus() requires the option safe="*" (that is, the * character is not encoded) to be consistent with CloudStack's internal encoder/decoder. Without this, API calls containing the * character will fail API authentication.