### PR TITLE
fix bug in using readline in Windows

### DIFF
--- a/cloudmonkey/cloudmonkey.py
+++ b/cloudmonkey/cloudmonkey.py
@@ -67,7 +67,8 @@ except ImportError, e:
     print("Module readline not found, autocompletions will fail", e)
 else:
     import rlcompleter
-    if 'libedit' in readline.__doc__:
+    readline_doc = getattr(readline, '__doc__', '')
+    if readline_doc is not None and 'libedit' in readline_doc:
         readline.parse_and_bind("bind ^I rl_complete")
         readline.parse_and_bind("bind ^R em-inc-search-prev")
         normal_readline = False


### PR DESCRIPTION
I found a bug with use of 'readline' for Python 2.7 on Windows 7. Cloudmonkey fails to run with this error:

File “c:\python27\lib\site-packages\cloudmonkey\cloudmonkey.py”  line 70 module>
            If ‘libedit’ in readline.__doc__
TypeError:  argument of type ‘NoneType’ is not iterable

It requires modification of cloudmonkey.py at line 70.

The error and fix are the same as reported here: 
http://bugs.python.org/issue18852
https://hg.python.org/cpython/rev/3070fdd58645

Note: I haven't tested this for Cloudmonkey in other Windows versions, or other Python versions.