### PR TITLE
Don't force connections to TLSv1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 Apache CloudStack CloudMonkey Changelog
 ---------------------------------------
 
+Version 5.3.4
+=============
+This release includes
+- Allow ssl version to be negotiated automatically
+
 Version 5.3.3
 =============
 This release includes

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ MAINTAINER "Apache CloudStack" <dev@cloudstack.apache.org>
 LABEL Description="Apache CloudStack CloudMonkey; Python based CloudStack command line interface"
 LABEL Vendor="Apache.org"
 LABEL License=ApacheV2
-LABEL Version=5.3.3
+LABEL Version=5.3.4
 
 COPY . /cloudstack-cloudmonkey
 RUN pip install requests

--- a/cloudmonkey/config.py
+++ b/cloudmonkey/config.py
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-__version__ = "5.3.3"
+__version__ = "5.3.4"
 __description__ = "Command Line Interface for Apache CloudStack"
 __maintainer__ = "The Apache CloudStack Team"
 __maintaineremail__ = "dev@cloudstack.apache.org"

--- a/cloudmonkey/requester.py
+++ b/cloudmonkey/requester.py
@@ -70,7 +70,7 @@ def login(url, username, password, domain="/", verifysslcert=False):
 
     sessionkey = ''
     session = requests.Session()
-    session.mount('https://', SSLAdapter(ssl.PROTOCOL_TLSv1))
+    session.mount('https://', SSLAdapter())
 
     try:
         resp = session.post(url, params=args, verify=verifysslcert)
@@ -217,7 +217,7 @@ def make_request(command, args, logger, url, credentials, expires,
     args["signature"] = sign_request(args, credentials['secretkey'])
 
     session = requests.Session()
-    session.mount('https://', SSLAdapter(ssl.PROTOCOL_TLSv1))
+    session.mount('https://', SSLAdapter())
 
     try:
         response = session.get(url, params=args, verify=verifysslcert)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -55,7 +55,7 @@ copyright = u'2012-2014, The Apache Software Foundation'
 # built documents.
 #
 # The short X.Y version.
-version = '5.3.3'
+version = '5.3.4'
 # The full version, including alpha/beta/rc tags.
 release = version
 


### PR DESCRIPTION
Forcing the connection to TLSv1 is actually downgrading connections that would otherwise be TLSv1_2. Cloudmonkey is better off auto-negotiating ssl/tls versions and versions should be enforced on the server side. Since the Go version is still alpha, it would be very useful to have the Python version play nice with TLSv1_2.