### PR TITLE
[fixe #29] create home configdir if not exist

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -80,7 +80,15 @@ func getDefaultConfigDir() string {
 		fmt.Println(err)
 		os.Exit(1)
 	}
-	return path.Join(home, ".cmk")
+	cmkHome := path.Join(home, ".cmk")
+	if _, err := os.Stat(cmkHome); os.IsNotExist(err) {
+		err := os.Mkdir(cmkHome, 0700)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+	}
+	return cmkHome
 }
 
 func defaultCoreConfig() Core {


### PR DESCRIPTION
Tested on Fedora29.

Create missing configDir if missing, exit if fail.
If the folder is not writable it fail and exit later in the config.

Do we support Windows ?