### PR TITLE
Add new filter based on jmespath for 5.3 version.

### DIFF
--- a/cloudmonkey/cloudmonkey.py
+++ b/cloudmonkey/cloudmonkey.py
@@ -278,6 +278,21 @@ class CloudMonkeyShell(cmd.Cmd, object):
                                         ensure_ascii=False,
                                         separators=(',', ': ')))
 
+        def print_result_jmespath(result, result_query):
+            try:
+                expression = jmespath.compile(result_query)
+            except Exception as e:
+                raise ValueError("Bad value for --query: %s \n\n %s" % (result_query, str(e)))
+            
+            try:
+                self.monkeyprint(json.dumps(expression.search(result),
+                                                    sort_keys=True,
+                                                    indent=2,
+                                                    ensure_ascii=False,
+                                                    separators=(',', ': ')))
+            except Exception as e:
+                raise ValueError("Bad formatted JSON for JMESPATH: %s \n\n %s" % (result, str(e)))
+
         def print_result_xml(result):
             custom_root = "CloudStack-%s" % self.profile.replace(" ", "_")
             xml = dicttoxml(result, attr_type=False, custom_root=custom_root)
@@ -368,6 +383,10 @@ class CloudMonkeyShell(cmd.Cmd, object):
 
         if self.display == "json":
             print_result_json(filtered_result)
+            return
+
+        if self.display == "jmespath":
+            print_result_jmespath(filtered_result, result_query)
             return
 
         if self.display == "xml":

--- a/cloudmonkey/cloudmonkey.py
+++ b/cloudmonkey/cloudmonkey.py
@@ -31,6 +31,7 @@ try:
     import sys
     import time
     import types
+    import jmespath
 
     from cachemaker import loadcache, savecache, monkeycache, splitverbsubject
     from config import __version__, __description__, __projecturl__

--- a/cloudmonkey/cloudmonkey.py
+++ b/cloudmonkey/cloudmonkey.py
@@ -235,7 +235,7 @@ class CloudMonkeyShell(cmd.Cmd, object):
             else:
                 print output
 
-    def print_result(self, result, result_filter=[]):
+    def print_result(self, result, result_filter=[], result_query=''):
         if not result or len(result) == 0:
             return
 
@@ -458,6 +458,10 @@ class CloudMonkeyShell(cmd.Cmd, object):
                                         x.partition("=")[2]],
                              args[1:])[x] for x in range(len(args) - 1))
 
+        field_query = []
+        if 'query' in args_dict:
+            field_query = args_dict.pop('query')
+        
         field_filter = []
         if 'filter' in args_dict:
             field_filter = filter(lambda x: x.strip() != '',
@@ -490,7 +494,7 @@ class CloudMonkeyShell(cmd.Cmd, object):
         try:
             responsekeys = filter(lambda x: 'response' in x, result.keys())
             for responsekey in responsekeys:
-                self.print_result(result[responsekey], field_filter)
+                self.print_result(result[responsekey], field_filter, field_query)
             if apiname.startswith("list") and "id" not in args_dict:
                 self.update_param_cache(apiname, result)
         except Exception as e:

--- a/cloudmonkey/config.py
+++ b/cloudmonkey/config.py
@@ -39,7 +39,7 @@ param_type = ['boolean', 'date', 'float', 'integer', 'short', 'list',
 iterable_type = ['set', 'list', 'object']
 
 # cloudmonkey display types
-display_types = ["json", "xml", "csv", "table", "default"]
+display_types = ["jmespath","json", "xml", "csv", "table", "default"]
 
 config_dir = expanduser('~/.cloudmonkey')
 config_file = expanduser(config_dir + '/config')

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ from cloudmonkey import __maintainer__, __maintaineremail__
 from cloudmonkey import __project__, __projecturl__, __projectemail__
 
 requires = [
+              'jmespath',
               'Pygments>=1.5',
               'argcomplete',
               'dicttoxml',


### PR DESCRIPTION
This add to cloudmonkey CLI the abilities to make a JMESPATH filter with following changes in version 5.3:

* Add new argument 'query'.
* Add new display type 'jmespath'.
* Import jmespath module.

Some examples:
![note-2019-02-27-111634](https://user-images.githubusercontent.com/11183983/53496944-da597a00-3a81-11e9-8382-4cae132b7210.png)

![note-2019-02-27-111306](https://user-images.githubusercontent.com/11183983/53496395-c19c9480-3a80-11e9-9d37-87ba55af7b6b.png)