### PR TITLE
Statically building the binary to not depend on gcc compiler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ PKGS     = $(or $(PKG),$(shell $(GO) list ./... | grep -v "^$(PACKAGE)/vendor/")
 TESTPKGS = $(shell $(GO) list -f '{{ if or .TestGoFiles .XTestGoFiles }}{{ .ImportPath }}{{ end }}' $(PKGS))
 GIT_SHA  = $(shell git rev-parse --short HEAD)
 
-GO      = go
+GO      = CGO_ENABLED=0 go
 GODOC   = godoc
 GOFMT   = gofmt
 TIMEOUT = 15


### PR DESCRIPTION
This is to statically build the `cmk` binary. It means it doesn't depend on gcc being present to work. The use case is that the `cmk` binary without this won't work in any `alpine` docker image.