### PR TITLE
Added new option to change default cmk config file.

### DIFF
--- a/cmd/command.go
+++ b/cmd/command.go
@@ -68,6 +68,7 @@ Allowed flags:
   -o        API response output format: json, text, table, column, csv
   -p        Server profile
   -d        Enable debug mode
+  -c        different config file path
 
 Default commands:
 %s

--- a/cmk.go
+++ b/cmk.go
@@ -45,10 +45,11 @@ func main() {
 	showVersion := flag.Bool("v", false, "show version")
 	debug := flag.Bool("d", false, "enable debug mode")
 	profile := flag.String("p", "", "server profile")
+	configFilePath := flag.String("c", "", "config file path")
 
 	flag.Parse()
 
-	cfg := config.NewConfig()
+	cfg := config.NewConfig(configFilePath)
 
 	if *showVersion {
 		fmt.Printf("%s %s (build: %s, %s)\n", cfg.Name(), cfg.Version(), GitSHA, BuildDate)

--- a/config/config.go
+++ b/config/config.go
@@ -331,6 +331,10 @@ func NewConfig(configFilePath *string) *Config {
 	defaultConf.ActiveProfile = nil
 	if *configFilePath != "" {
 		defaultConf.ConfigFile, _ = filepath.Abs(*configFilePath)
+		if _, err := os.Stat(defaultConf.ConfigFile); os.IsNotExist(err) {
+			fmt.Println("Config file doesn't exist.")
+			os.Exit(1)
+		}
 	}
 	cfg := reloadConfig(defaultConf)
 	LoadCache(cfg)

--- a/config/config.go
+++ b/config/config.go
@@ -24,6 +24,7 @@ import (
 	"net/http/cookiejar"
 	"os"
 	"path"
+	"path/filepath"
 	"strconv"
 	"time"
 
@@ -324,10 +325,13 @@ func (c *Config) UpdateConfig(key string, value string, update bool) {
 }
 
 // NewConfig creates or reload config and loads API cache
-func NewConfig() *Config {
+func NewConfig(configFilePath *string) *Config {
 	defaultConf := defaultConfig()
 	defaultConf.Core = nil
 	defaultConf.ActiveProfile = nil
+	if *configFilePath != "" {
+		defaultConf.ConfigFile, _ = filepath.Abs(*configFilePath)
+	}
 	cfg := reloadConfig(defaultConf)
 	LoadCache(cfg)
 	return cfg


### PR DESCRIPTION
Cloudmonkey command lets us use a different config file rather than the default one. This pull request added the same functionality to the `cmk` command.

```
cmk -c ./my-config
```