### PR TITLE
Inclusivity changes for CloudStack - rename some offensive words/terms as appropriate, that are meaningful and inclusive.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## CloudMonkey [![Build Status](https://travis-ci.org/apache/cloudstack-cloudmonkey.svg?branch=master)](https://travis-ci.org/apache/cloudstack-cloudmonkey)[![](https://images.microbadger.com/badges/version/apache/cloudstack-cloudmonkey.svg)](https://hub.docker.com/r/apache/cloudstack-cloudmonkey)[![cloudmonkey](https://snapcraft.io/cloudmonkey/badge.svg)](https://snapcraft.io/cloudmonkey)
+## CloudMonkey [![Build Status](https://travis-ci.org/apache/cloudstack-cloudmonkey.svg?branch=main)](https://travis-ci.org/apache/cloudstack-cloudmonkey)[![](https://images.microbadger.com/badges/version/apache/cloudstack-cloudmonkey.svg)](https://hub.docker.com/r/apache/cloudstack-cloudmonkey)[![cloudmonkey](https://snapcraft.io/cloudmonkey/badge.svg)](https://snapcraft.io/cloudmonkey)
 
 `cloudmonkey` :cloud::monkey_face: is a command line interface (CLI) for
 [Apache CloudStack](http://cloudstack.apache.org).
@@ -57,7 +57,7 @@ Report issue(s) on the `user` mailing list and/or open a Github [issue](https://
 3. Commit your change
 4. Write tests for your change if applicable
 5. Run the tests, ensuring they all pass
-6. Submit a [Pull Request](https://github.com/apache/cloudstack-cloudmonkey/pull/new/master) using Github
+6. Submit a [Pull Request](https://github.com/apache/cloudstack-cloudmonkey/pull/new/main) using Github
 
 ### History
 

--- a/performrelease.sh
+++ b/performrelease.sh
@@ -19,7 +19,7 @@
 version='TESTBUILD'
 sourcedir=~/cloudstack-cloudmonkey
 outputdir=/tmp/cloudstack-cloudmonkey-build/
-branch='master'
+branch='main'
 tag='no'
 certid='X'
 committosvn='X'
@@ -27,7 +27,7 @@ committosvn='X'
 usage(){
     echo "usage: $0 -v version [-b branch] [-s source dir] [-o output dir] [-t] [-u] [-c] [-h]"
     echo "  -v sets the version"
-    echo "  -b sets the branch (defaults to 'master')"
+    echo "  -b sets the branch (defaults to 'main')"
     echo "  -s sets the source directory (defaults to $sourcedir)"
     echo "  -o sets the output directory (defaults to $outputdir)"
     echo "  -t tags the git repo with the version"


### PR DESCRIPTION
Inclusivity changes for CloudStack - rename some offensive words/terms as appropriate, that are meaningful and inclusive.

- Renamed default git branch name from 'master' to 'main'.