### PR TITLE
Validate arguments passed while setting configuration

### DIFF
--- a/cmd/set.go
+++ b/cmd/set.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"errors"
 
 	"github.com/apache/cloudstack-cloudmonkey/config"
 )
@@ -33,7 +34,7 @@ func init() {
 			"prompt":     {"🐵", "🐱", "random"},
 			"asyncblock": {"true", "false"},
 			"timeout":    {"600", "1800", "3600"},
-			"output":     {"json", "text", "table", "column", "csv"},
+			"output":     config.GetOutputFormats(),
 			"profile":    {},
 			"url":        {},
 			"username":   {},
@@ -55,6 +56,15 @@ func init() {
 			if r.Args[len(r.Args)-1] == "-h" {
 				fmt.Println("Usage: set <subcommand> <option>. Press tab-tab to see available subcommands and options.")
 				return nil
+			}
+			if subCommand == "display" {
+				subCommand = "output"
+			}
+			validArgs := r.Command.SubCommands[subCommand]
+			if len(validArgs) != 0 && subCommand != "timeout" {
+				if !config.CheckIfValuePresent(validArgs, value) {
+					return errors.New("Invalid value set for " + subCommand +". Supported values: " + strings.Join(validArgs, ", ") )
+				}
 			}
 			r.Config.UpdateConfig(subCommand, value, true)
 

--- a/cmk.go
+++ b/cmk.go
@@ -41,7 +41,8 @@ func init() {
 }
 
 func main() {
-	outputFormat := flag.String("o", "", "output format: json, text, table, column, csv")
+	validFormats := strings.Join(config.GetOutputFormats(), ",")
+	outputFormat := flag.String("o", "", "output format: " + validFormats)
 	showVersion := flag.Bool("v", false, "show version")
 	debug := flag.Bool("d", false, "enable debug mode")
 	profile := flag.String("p", "", "server profile")
@@ -61,6 +62,10 @@ func main() {
 	}
 
 	if *outputFormat != "" {
+		if !config.CheckIfValuePresent(config.GetOutputFormats(), *outputFormat) {
+			fmt.Println("Invalid value set for output format. Supported values: " + validFormats)
+			os.Exit(1)
+		}
 		cfg.UpdateConfig("output", *outputFormat, false)
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -74,6 +74,18 @@ type Config struct {
 	ActiveProfile *ServerProfile
 }
 
+func GetOutputFormats() []string {
+ return []string {"column", "csv", "json", "table", "text"}
+}
+
+func CheckIfValuePresent(dataset []string, element string) bool {
+	for _, arg := range dataset {
+		if arg == element {
+			return true
+		}
+	}
+	return false
+}
 // CacheFile returns the path to the cache file for a server profile
 func (c Config) CacheFile() string {
 	cacheDir := path.Join(c.Dir, "profiles")


### PR DESCRIPTION
Fixes: https://github.com/apache/cloudstack-cloudmonkey/issues/77

Post Fix:
```
go run cmk.go -o default
Invalid value set for output format. Supported values: column,csv,json,table,text
exit status 1


$ go run cmk.go 
Apache CloudStack 🐵 CloudMonkey 6.1.0
Report issues: https://github.com/apache/cloudstack-cloudmonkey/issues

(localcloud) 🐱 > set display default
🙈 Error: Invalid value set for output. Supported values: column, csv, json, table, text
(localcloud) 🐱 >  


(localcloud) 🐱 > set output default
🙈 Error: Invalid value set for output. Supported values: column, csv, json, table, text
(localcloud) 🐱 >  



```