### PR TITLE
Verify user access to config file

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -85,7 +85,22 @@ func (c Config) CacheFile() string {
 	return path.Join(cacheDir, cacheFileName)
 }
 
+func hasAccess(path string) bool {
+	status := true
+	file, err := os.Open(path)
+	if (err != nil) {
+		status = false
+	}
+	file.Close()
+	return status
+}
+
 func checkAndCreateDir(path string) string {
+	isAccsessible := hasAccess(path)
+	if !isAccsessible {
+		fmt.Println("User isn't authorized to access the config file")
+		os.Exit(1)
+	}
 	if fileInfo, err := os.Stat(path); os.IsNotExist(err) || !fileInfo.IsDir() {
 		err := os.Mkdir(path, 0700)
 		if err != nil {


### PR DESCRIPTION
Fixes: https://github.com/apache/cloudstack-cloudmonkey/issues/68

Prior Fix:
```
$ cmk
Failed to grab config file lock, please try again
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x6952e8]

goroutine 1 [running]:
github.com/apache/cloudstack-cloudmonkey/config.checkAndCreateDir(0xc00001a620, 0x19, 0x2, 0xc00001a620)
	/home/rohit/lab/apache/cloudmonkey/config/config.go:89 +0x158
github.com/apache/cloudstack-cloudmonkey/config.Config.CacheFile(0xc0000166f0, 0x10, 0xc00001a560, 0x17, 0xc00001a580, 0x18, 0xc00001a5a0, 0x14, 0x0, 0x0, ...)
	/home/rohit/lab/apache/cloudmonkey/config/config.go:84 +0xd7
github.com/apache/cloudstack-cloudmonkey/config.LoadCache(0xc0000285a0, 0xc0000285a0, 0x0)
	/home/rohit/lab/apache/cloudmonkey/config/cache.go:83 +0x95
github.com/apache/cloudstack-cloudmonkey/config.NewConfig(0xc0000281e0)
	/home/rohit/lab/apache/cloudmonkey/config/config.go:333 +0x54
main.main()
	/home/rohit/lab/apache/cloudmonkey/cmk.go:51 +0x1bd

```
Post Fix:
#### Tested by changing the permission of cmk directory and then trying to login to cmk shell prompt
```
$ go run cmk.go 
User isn't authorized to access the config file
exit status 1
[13:21:49] pearl@pearl-XPS-15-7590:~/go/src/github.com/pearl1594/cloudstack-cloudmonkey$ 

```

#### Tested by changing the permission of cmk directory when user already has a cmk session running
```
$ go run cmk.go 
Apache CloudStack 🐵 CloudMonkey 6.1.0
Report issues: https://github.com/apache/cloudstack-cloudmonkey/issues

(localcloud) 🐱 > set debug true
[debug] UpdateConfig key:debug value:true update:true
User isn't authorized to access the config file
exit status 1

```