### PR TITLE
Prevent ACS commands starting with sync to get redirected to API discovery

### DIFF
--- a/cli/exec.go
+++ b/cli/exec.go
@@ -58,7 +58,7 @@ func ExecCmd(args []string) error {
 	}
 
 	command := cmd.FindCommand(args[0])
-	if command != nil {
+	if command != nil && ((args[0] == "sync" && len(args) == 1) || args[0] != "sync") {
 		return command.Handle(cmd.NewRequest(command, cfg, args[1:]))
 	}
 

--- a/cli/exec.go
+++ b/cli/exec.go
@@ -58,7 +58,7 @@ func ExecCmd(args []string) error {
 	}
 
 	command := cmd.FindCommand(args[0])
-	if command != nil && ((args[0] == "sync" && len(args) == 1) || args[0] != "sync") {
+	if command != nil && !(args[0] == "sync" && len(args) > 1) {
 		return command.Handle(cmd.NewRequest(command, cfg, args[1:]))
 	}
 


### PR DESCRIPTION
Fixes: https://github.com/apache/cloudstack-cloudmonkey/issues/81
```
/go/src/github.com/pearl1594/cloudstack-cloudmonkey$ go run cmk.go
Apache CloudStack 🐵 CloudMonkey 6.1.0
Report issues: https://github.com/apache/cloudstack-cloudmonkey/issues

(localcloud) 🐱 > sync storagepool id=0bbd54fe-b348-3e3d-9b91-b453a21bc43a (PS2)
{
  "accountid": "6b71e9af-cf22-11eb-9edd-50eb7122da94",
  "cmd": "org.apache.cloudstack.api.command.admin.storage.SyncStoragePoolCmd",
  "completed": "2021-07-02T13:01:21+0530",
  "created": "2021-07-02T13:01:21+0530",
  "jobid": "0cd7299c-679a-4691-b990-1fce8f9ddf4f",
  "jobprocstatus": 0,
  "jobresult": {
    "errorcode": 431,
    "errortext": "SyncStoragePool API is currently supported only for storage type of datastore cluster"
  },
  "jobresultcode": 530,
  "jobresulttype": "object",
  "jobstatus": 2,
  "userid": "6b71f7f1-cf22-11eb-9edd-50eb7122da94"
}
🙈 Error: async API failed for job 0cd7299c-679a-4691-b990-1fce8f9ddf4f


(localcloud) 🐱 > sync
Discovered 604 APIs

```