### PR TITLE
call API when sync has args

### DIFF
--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -26,6 +26,10 @@ func init() {
 		Name: "sync",
 		Help: "Discovers and updates APIs",
 		Handle: func(r *Request) error {
+			if len(r.Args) >= 1 {
+				catchAllHandler := GetAPIHandler()
+				return catchAllHandler.Handle(NewRequest(catchAllHandler, r.Config, append([]string{"sync"}, r.Args...)))
+			}
 			spinner := r.Config.StartSpinner("discovering APIs, please wait...")
 			response, err := NewAPIRequest(r, "listApis", []string{"listall=true"}, false)
 			r.Config.StopSpinner(spinner)


### PR DESCRIPTION
Fixes #81 

Changes in this PR will allow making API calls when sync is called with arguments.

```
⇒  make run
▶  Running gofmt…
▶  Building executable… 022abb6
▶  Done!
./bin/cmk
Apache CloudStack 🐵 CloudMonkey 6.1.0
Report issues: https://github.com/apache/cloudstack-cloudmonkey/issues

(sblab) 🐱 > sync
Discovered 614 APIs
(sblab) 🐱 > sync storagepool -h
syncStoragePool: Sync storage pool with management server (currently supported for Datastore Cluster in VMware and syncs the datastores in it)
This API is asynchronous.
Required params: id, 
API Params               Type     Description
==========               ====     ===========
id                       uuid     Storage pool id
(sblab) 🐱 > sync storagepool id=243f307c-6135-3772-8186-be65c695220b 
{
  "accountid": "67e72573-cd47-11eb-bd54-1e009200048a",
  "cmd": "org.apache.cloudstack.api.command.admin.storage.SyncStoragePoolCmd",
  "completed": "2021-07-02T07:54:44+0000",
  "created": "2021-07-02T07:54:44+0000",
  "jobid": "dda93797-e1df-4693-8796-687c8f7da09c",
  "jobprocstatus": 0,
  "jobresult": {
    "errorcode": 431,
    "errortext": "SyncStoragePool API is currently supported only for storage type of datastore cluster"
  },
  "jobresultcode": 530,
  "jobresulttype": "object",
  "jobstatus": 2,
  "userid": "67e859fb-cd47-11eb-bd54-1e009200048a"
}
🙈 Error: async API failed for job dda93797-e1df-4693-8796-687c8f7da09c
```