### PR TITLE
Use local profile if present

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -42,6 +42,11 @@ const (
 	TEXT   = "text"
 )
 
+const (
+	LOCALCLOUD = "localcloud"
+	LOCAL = "local"
+)
+
 // ServerProfile describes a management server
 type ServerProfile struct {
 	URL       string       `ini:"url"`
@@ -105,6 +110,25 @@ func getDefaultConfigDir() string {
 	return checkAndCreateDir(path.Join(home, ".cmk"))
 }
 
+func getProfileName () string {
+	_,err := os.Stat(path.Join(getDefaultConfigDir(), "config"))
+	if err != nil {
+		return LOCALCLOUD
+	}
+	conf, err := ini.Load(path.Join(getDefaultConfigDir(), "config"))
+	if err != nil {
+		return LOCALCLOUD
+	}
+	section, err := conf.GetSection(LOCAL)
+	if section == nil || err != nil {
+		return LOCALCLOUD
+	}
+	if section != nil {
+		return LOCAL
+	}
+	return LOCALCLOUD
+}
+
 func defaultCoreConfig() Core {
 	return Core{
 		Prompt:      "🐱",
@@ -112,7 +136,7 @@ func defaultCoreConfig() Core {
 		Timeout:     1800,
 		Output:      JSON,
 		VerifyCert:  true,
-		ProfileName: "localcloud",
+		ProfileName: getProfileName(),
 	}
 }
 


### PR DESCRIPTION
Fixes: https://github.com/apache/cloudstack-cloudmonkey/issues/69
Use local profile, if present (in case of older versions of cloudmonkey) 

#### Test Performed:
```
 go run cmk.go -p local
Apache CloudStack 🐵 CloudMonkey 6.1.0
Report issues: https://github.com/apache/cloudstack-cloudmonkey/issues

(local) 🐱 >  
```

And the corresponding cmk config has only local profile:
```
cat .cmk/config
prompt     = 🐱
asyncblock = true
timeout    = 1800
output     = json
verifycert = true
profile    = local

[local]
url       = http://localhost:8080/client/api
username  = admin
password  = password
domain    = /
apikey    = 
secretkey = 

```