### PR TITLE
Print map in readable format when display format is set to text

### DIFF
--- a/cmd/output.go
+++ b/cmd/output.go
@@ -35,7 +35,7 @@ func jsonify(value interface{}) string {
 		return ""
 	}
 	if reflect.TypeOf(value).Kind() == reflect.Map || reflect.TypeOf(value).Kind() == reflect.Slice {
-		jsonStr, err := json.Marshal(value)
+		jsonStr, err := json.MarshalIndent(value, "", "")
 		if err == nil {
 			value = string(jsonStr)
 		}


### PR DESCRIPTION
Addresses: https://github.com/apache/cloudstack-cloudmonkey/issues/74 
Currently, when output format is set to `text`, cmk response is as follows:
```
(testenv) 🐱 > create zone name=test100 dns1=8.8.8.8 internaldns1=8.8.8.8 networktype=Advanced^C
(testenv) 🐱 > create domain name=test10
domain = {"haschild":false,"id":"1a305c99-656a-4d28-a08c-a73b89b6523c","level":1,"name":"test10","parentdomainid":"d83d7d66-ef91-11eb-adc6-1e00e8000282","parentdomainname":"ROOT","path":"ROOT/test10","secondarystoragetotal":0}
```

However, cloudmonkey versions < 6.0.0, displayed the output as follows:
```
(testenv) 🐵 > create domain name=test11
domain:
id = e6e2e5b0-7b7e-4ff2-bcee-60b4802cab95
name = test11
haschild = False
level = 1
parentdomainid = d83d7d66-ef91-11eb-adc6-1e00e8000282
parentdomainname = ROOT
path = ROOT/test11
secondarystoragetotal = 0.0
```


This PR attempts to align to the output format as seen in older versions of cloudmonkey:
```
(testenv) 🐱 > create domain name=test12New
domain = {
"haschild": false,
"id": "df4684b9-d722-4f3a-882e-062a345c5950",
"level": 1,
"name": "test12New",
"parentdomainid": "d83d7d66-ef91-11eb-adc6-1e00e8000282",
"parentdomainname": "ROOT",
"path": "ROOT/test12New",
"secondarystoragetotal": 0
}
```
#### A slice/Map output: 

##### Prior Fix:
```
(testenv) 🐱 > list virtualmachines id=aa3ed00b-99ac-4461-a73c-43e69af9356d filter=name,id,hypervisor,nic,details,zon
count = 1
virtualmachine:
id = aa3ed00b-99ac-4461-a73c-43e69af9356d
hypervisor = VMware
nic = [{"broadcasturi":"vlan://1468","deviceid":"0","extradhcpoption":[],"id":"7c33b5e5-6899-463f-8a30-c44e66f01b98","isdefault":true,"isolationuri":"vlan://1468","macaddress":"02:00:1c:b5:00:01","networkid":"a2db521b-57be-4b7a-bd49-a9cef71dde51","networkname":"test","secondaryip":[],"traffictype":"Guest","type":"L2"}]
details = {"cpuOvercommitRatio":"2.0","dataDiskController":"osdefault","memoryOvercommitRatio":"1.0","rootDiskController":"ide"}
name = VM-aa3ed00b-99ac-4461-a73c-43e69af9356d
```

#### Output in cloudmonkey v5.3.3
```
(testenv) 🐵 > list virtualmachines id=aa3ed00b-99ac-4461-a73c-43e69af9356d filter=name,id,hypervisor,nic,details,zone
count = 1
virtualmachine:
id = aa3ed00b-99ac-4461-a73c-43e69af9356d
name = VM-aa3ed00b-99ac-4461-a73c-43e69af9356d
details:
cpuOvercommitRatio = 2.0
dataDiskController = osdefault
memoryOvercommitRatio = 1.0
rootDiskController = ide
hypervisor = VMware
nic:
id = 7c33b5e5-6899-463f-8a30-c44e66f01b98
broadcasturi = vlan://1468
deviceid = 0
extradhcpoption:
isdefault = True
isolationuri = vlan://1468
macaddress = 02:00:1c:b5:00:01
networkid = a2db521b-57be-4b7a-bd49-a9cef71dde51
networkname = test
secondaryip:
traffictype = Guest
type = L2
```

#### Post Fix:
```
(testenv) 🐱 > list virtualmachines id=aa3ed00b-99ac-4461-a73c-43e69af9356d filter=name,id,hypervisor,nic,details,zoneid
count = 1
virtualmachine:
hypervisor = VMware
nic = [
{
"broadcasturi": "vlan://1468",
"deviceid": "0",
"extradhcpoption": [],
"id": "7c33b5e5-6899-463f-8a30-c44e66f01b98",
"isdefault": true,
"isolationuri": "vlan://1468",
"macaddress": "02:00:1c:b5:00:01",
"networkid": "a2db521b-57be-4b7a-bd49-a9cef71dde51",
"networkname": "test",
"secondaryip": [],
"traffictype": "Guest",
"type": "L2"
}
]
details = {
"cpuOvercommitRatio": "2.0",
"dataDiskController": "osdefault",
"memoryOvercommitRatio": "1.0",
"rootDiskController": "ide"
}
zoneid = c80f96f5-f7f9-40b2-aa10-58e34b00a4e4
name = VM-aa3ed00b-99ac-4461-a73c-43e69af9356d
id = aa3ed00b-99ac-4461-a73c-43e69af9356d

```
