### PR TITLE
Avoids adding newline to list/map output data for output format other than text

### DIFF
--- a/cmd/output.go
+++ b/cmd/output.go
@@ -30,12 +30,18 @@ import (
 	"github.com/olekukonko/tablewriter"
 )
 
-func jsonify(value interface{}) string {
+func jsonify(value interface{}, format string) string {
 	if value == nil {
 		return ""
 	}
 	if reflect.TypeOf(value).Kind() == reflect.Map || reflect.TypeOf(value).Kind() == reflect.Slice {
-		jsonStr, err := json.MarshalIndent(value, "", "")
+		var jsonStr []byte
+		var err error
+		if (format == "text") {
+			jsonStr, err = json.MarshalIndent(value, "", "")
+		} else {
+			jsonStr, err = json.Marshal(value)
+		}
 		if err == nil {
 			value = string(jsonStr)
 		}
@@ -51,6 +57,7 @@ func printJSON(response map[string]interface{}) {
 }
 
 func printText(response map[string]interface{}) {
+	format := "text"
 	for k, v := range response {
 		valueType := reflect.TypeOf(v)
 		if valueType.Kind() == reflect.Slice {
@@ -62,19 +69,20 @@ func printText(response map[string]interface{}) {
 				row, isMap := item.(map[string]interface{})
 				if isMap {
 					for field, value := range row {
-						fmt.Printf("%s = %v\n", field, jsonify(value))
+						fmt.Printf("%s = %v\n", field, jsonify(value, format))
 					}
 				} else {
 					fmt.Printf("%v\n", item)
 				}
 			}
 		} else {
-			fmt.Printf("%v = %v\n", k, jsonify(v))
+			fmt.Printf("%v = %v\n", k, jsonify(v, format))
 		}
 	}
 }
 
 func printTable(response map[string]interface{}, filter []string) {
+	format := "table"
 	table := tablewriter.NewWriter(os.Stdout)
 	for k, v := range response {
 		valueType := reflect.TypeOf(v)
@@ -103,7 +111,7 @@ func printTable(response map[string]interface{}, filter []string) {
 				}
 				var rowArray []string
 				for _, field := range header {
-					rowArray = append(rowArray, jsonify(row[field]))
+					rowArray = append(rowArray, jsonify(row[field], format))
 				}
 				table.Append(rowArray)
 			}
@@ -115,6 +123,7 @@ func printTable(response map[string]interface{}, filter []string) {
 }
 
 func printColumn(response map[string]interface{}, filter []string) {
+	format := "column"
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', tabwriter.DiscardEmptyColumns)
 	for _, v := range response {
 		valueType := reflect.TypeOf(v)
@@ -143,7 +152,7 @@ func printColumn(response map[string]interface{}, filter []string) {
 				}
 				var values []string
 				for _, key := range header {
-					values = append(values, jsonify(row[strings.ToLower(key)]))
+					values = append(values, jsonify(row[strings.ToLower(key)], format))
 				}
 				fmt.Fprintln(w, strings.Join(values, "\t"))
 			}
@@ -153,6 +162,7 @@ func printColumn(response map[string]interface{}, filter []string) {
 }
 
 func printCsv(response map[string]interface{}, filter []string) {
+	format := "csv"
 	for _, v := range response {
 		valueType := reflect.TypeOf(v)
 		if valueType.Kind() == reflect.Slice || valueType.Kind() == reflect.Map {
@@ -180,7 +190,7 @@ func printCsv(response map[string]interface{}, filter []string) {
 				}
 				var values []string
 				for _, key := range header {
-					values = append(values, jsonify(row[key]))
+					values = append(values, jsonify(row[key], format))
 				}
 				fmt.Println(strings.Join(values, ","))
 			}


### PR DESCRIPTION
This PR prevents adding a newline to the map/list response data for other output formats, namely, json, column, table, etc in order to comply with the earlier behavior.

#### Prior Fix
cmk v6.1.0 - Output for csv
``` 
(testenv) 🐱 > set output csv
(testenv) 🐱 > list virtualmachines filter=name,id,hypervisor,nic,details,zoneid
name,id,hypervisor,nic,details,zoneid
VM-3fb3ba0d-8a12-4dfd-98b6-2e00d5e99ec4,3fb3ba0d-8a12-4dfd-98b6-2e00d5e99ec4,VMware,[
{
"broadcasturi": "vlan://1468",
"deviceid": "0",
"extradhcpoption": [],
"id": "01fdeb96-c638-41f0-bb04-5a40a836b8be",
"isdefault": true,
"isolationuri": "vlan://1468",
"macaddress": "02:00:21:07:00:02",
"networkid": "a2db521b-57be-4b7a-bd49-a9cef71dde51",
"networkname": "test",
"secondaryip": [],
"traffictype": "Guest",
"type": "L2"
}
],{
"cpuOvercommitRatio": "2.0",
"dataDiskController": "osdefault",
"memoryOvercommitRatio": "1.0",
"rootDiskController": "ide"
},c80f96f5-f7f9-40b2-aa10-58e34b00a4e4
VM-aa3ed00b-99ac-4461-a73c-43e69af9356d,aa3ed00b-99ac-4461-a73c-43e69af9356d,VMware,[
{
"broadcasturi": "vlan://1468",
"deviceid": "0",
"extradhcpoption": [],
"id": "7c33b5e5-6899-463f-8a30-c44e66f01b98",
"isdefault": true,
"isolationuri": "vlan://1468",
"macaddress": "02:00:1c:b5:00:01",
"networkid": "a2db521b-57be-4b7a-bd49-a9cef71dde51",
"networkname": "test",
"secondaryip": [],
"traffictype": "Guest",
"type": "L2"
}
],{
"cpuOvercommitRatio": "2.0",
"dataDiskController": "osdefault",
"memoryOvercommitRatio": "1.0",
"rootDiskController": "ide"
},c80f96f5-f7f9-40b2-aa10-58e34b00a4e4

```

v5.3.3
```
(testenv) 🐵 > set display csv
(testenv) 🐵 > list virtualmachines filter=name,id,hypervisor,nic,details,zoneid
zoneid,id,details,nic,name,hypervisor
c80f96f5-f7f9-40b2-aa10-58e34b00a4e4,3fb3ba0d-8a12-4dfd-98b6-2e00d5e99ec4,"{u'dataDiskController': u'osdefault', u'memoryOvercommitRatio': u'1.0', u'cpuOvercommitRatio': u'2.0', u'rootDiskController': u'ide'}","[{u'networkid': u'a2db521b-57be-4b7a-bd49-a9cef71dde51', u'macaddress': u'02:00:21:07:00:02', u'isolationuri': u'vlan://1468', u'networkname': u'test', u'extradhcpoption': [], u'traffictype': u'Guest', u'deviceid': u'0', u'id': u'01fdeb96-c638-41f0-bb04-5a40a836b8be', u'secondaryip': [], u'type': u'L2', u'broadcasturi': u'vlan://1468', u'isdefault': True}]",VM-3fb3ba0d-8a12-4dfd-98b6-2e00d5e99ec4,VMware
c80f96f5-f7f9-40b2-aa10-58e34b00a4e4,aa3ed00b-99ac-4461-a73c-43e69af9356d,"{u'dataDiskController': u'osdefault', u'memoryOvercommitRatio': u'1.0', u'cpuOvercommitRatio': u'2.0', u'rootDiskController': u'ide'}","[{u'networkid': u'a2db521b-57be-4b7a-bd49-a9cef71dde51', u'macaddress': u'02:00:1c:b5:00:01', u'isolationuri': u'vlan://1468', u'networkname': u'test', u'extradhcpoption': [], u'traffictype': u'Guest', u'deviceid': u'0', u'id': u'7c33b5e5-6899-463f-8a30-c44e66f01b98', u'secondaryip': [], u'type': u'L2', u'broadcasturi': u'vlan://1468', u'isdefault': True}]",VM-aa3ed00b-99ac-4461-a73c-43e69af9356d,VMware
(testenv) 🐵 > 

```



Post Fix:

```
(testenv) 🐱 > set output csv
(testenv) 🐱 > list virtualmachines filter=name,id,hypervisor,nic,details,zoneid
name,id,hypervisor,nic,details,zoneid
VM-3fb3ba0d-8a12-4dfd-98b6-2e00d5e99ec4,3fb3ba0d-8a12-4dfd-98b6-2e00d5e99ec4,VMware,[{"broadcasturi":"vlan://1468","deviceid":"0","extradhcpoption":[],"id":"01fdeb96-c638-41f0-bb04-5a40a836b8be","isdefault":true,"isolationuri":"vlan://1468","macaddress":"02:00:21:07:00:02","networkid":"a2db521b-57be-4b7a-bd49-a9cef71dde51","networkname":"test","secondaryip":[],"traffictype":"Guest","type":"L2"}],{"cpuOvercommitRatio":"2.0","dataDiskController":"osdefault","memoryOvercommitRatio":"1.0","rootDiskController":"ide"},c80f96f5-f7f9-40b2-aa10-58e34b00a4e4
VM-aa3ed00b-99ac-4461-a73c-43e69af9356d,aa3ed00b-99ac-4461-a73c-43e69af9356d,VMware,[{"broadcasturi":"vlan://1468","deviceid":"0","extradhcpoption":[],"id":"7c33b5e5-6899-463f-8a30-c44e66f01b98","isdefault":true,"isolationuri":"vlan://1468","macaddress":"02:00:1c:b5:00:01","networkid":"a2db521b-57be-4b7a-bd49-a9cef71dde51","networkname":"test","secondaryip":[],"traffictype":"Guest","type":"L2"}],{"cpuOvercommitRatio":"2.0","dataDiskController":"osdefault","memoryOvercommitRatio":"1.0","rootDiskController":"ide"},c80f96f5-f7f9-40b2-aa10-58e34b00a4e4
(testenv) 🐱 >  

```
