### PR TITLE
Validate user access to config file IF it exists

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -108,17 +108,17 @@ func hasAccess(path string) bool {
 }
 
 func checkAndCreateDir(path string) string {
-	isAccsessible := hasAccess(path)
-	if !isAccsessible {
-		fmt.Println("User isn't authorized to access the config file")
-		os.Exit(1)
-	}
 	if fileInfo, err := os.Stat(path); os.IsNotExist(err) || !fileInfo.IsDir() {
 		err := os.Mkdir(path, 0700)
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)
 		}
+	}
+	isAccsessible := hasAccess(path)
+	if !isAccsessible {
+		fmt.Println("User isn't authorized to access the config file")
+		os.Exit(1)
 	}
 	return path
 }


### PR DESCRIPTION
In case of fresh installation of cloudmonkey, where the config file `~/.cmk/` isn't present, cloudmonkey fails to start due to user access failure, as seen during docker build:
``` 
pearl@pearl-XPS-15-7590:~/go/src/github.com/pearl1594/cloudstack-cloudmonkey$ sudo docker build .
Sending build context to Docker daemon  13.22MB
Step 1/11 : FROM debian:sid as builder
 ---> ebac6aca2cc8
Step 2/11 : MAINTAINER "Apache CloudStack" <dev@cloudstack.apache.org>
 ---> Using cache
 ---> dc702e368f3f
Step 3/11 : LABEL Description="Apache CloudStack CloudMonkey; Go based CloudStack command line interface"
 ---> Using cache
 ---> 6d14a949dff6
Step 4/11 : LABEL Vendor="Apache.org"
 ---> Using cache
 ---> a4bc0ef6fa82
Step 5/11 : LABEL License=ApacheV2
 ---> Using cache
 ---> 36ae8931fc8f
Step 6/11 : LABEL Version=6.2.0
 ---> Using cache
 ---> 024b6b05b985
Step 7/11 : WORKDIR /work/
 ---> Using cache
 ---> 09ad0a15c1d0
Step 8/11 : RUN apt -y update && apt -y install git golang-go build-essential &&     git clone https://github.com/apache/cloudstack-cloudmonkey.git &&     go version &&     cd cloudstack-cloudmonkey &&     make all &&     pwd &&     ls -alh ./bin/cmk
 ---> Using cache
 ---> 7b84e2ccc304
Step 9/11 : FROM debian:stable
 ---> ff50729f54b3
Step 10/11 : COPY --from=builder /work/cloudstack-cloudmonkey/bin/cmk /usr/bin/
 ---> Using cache
 ---> 5152257949db
Step 11/11 : RUN apt-get -y update && uname -a && mkdir -p /root/.cmk/ &&    cmk version && cmk help && ls -alh /root/
 ---> Running in 8bafb0c4e125
Get:1 http://security.debian.org/debian-security stable/updates InRelease [65.4 kB]
Get:2 http://deb.debian.org/debian stable InRelease [122 kB]
Get:3 http://security.debian.org/debian-security stable/updates/main amd64 Packages [298 kB]
Get:4 http://deb.debian.org/debian stable-updates InRelease [51.9 kB]
Get:5 http://deb.debian.org/debian stable/main amd64 Packages [7907 kB]
Get:6 http://deb.debian.org/debian stable-updates/main amd64 Packages [15.2 kB]
Fetched 8459 kB in 4s (2368 kB/s)
Reading package lists...
Linux 8bafb0c4e125 5.4.0-80-generic #90-Ubuntu SMP Fri Jul 9 22:49:44 UTC 2021 x86_64 GNU/Linux
User isn't authorized to access the config file
The command '/bin/sh -c apt-get -y update && uname -a && mkdir -p /root/.cmk/ &&    cmk version && cmk help && ls -alh /root/' returned a non-zero code: 1

```


### Post fix
Docker image successfully builds and starts 
```
$ sudo docker build .
[sudo] password for pearl: 
Sending build context to Docker daemon  13.22MB
Step 1/11 : FROM debian:sid as builder
 ---> ebac6aca2cc8
Step 2/11 : MAINTAINER "Apache CloudStack" <dev@cloudstack.apache.org>
 ---> Using cache
 ---> dc702e368f3f
Step 3/11 : LABEL Description="Apache CloudStack CloudMonkey; Go based CloudStack command line interface"
 ---> Using cache
 ---> 6d14a949dff6
Step 4/11 : LABEL Vendor="Apache.org"
 ---> Using cache
 ---> a4bc0ef6fa82
Step 5/11 : LABEL License=ApacheV2
 ---> Using cache
 ---> 36ae8931fc8f
Step 6/11 : LABEL Version=6.2.0
 ---> Using cache
 ---> 024b6b05b985
Step 7/11 : WORKDIR /work/
 ---> Using cache
 ---> 09ad0a15c1d0
.....
....
Apache CloudStack 🐵 CloudMonkey 6.2.0
usage: cmk [flags] [commands|apis] [-h]

CloudMonkey (cmk) 🐵 is a command line interface for Apache CloudStack.

Allowed flags:
  -h        Show this help message or API doc when specified after an API
  -v        Print version
  -o        API response output format: json, text, table, column, csv
  -p        Server profile
  -d        Enable debug mode
  -c        different config file path

Default commands:
  exit      Exits
  help      Help
  set       Configures options for cmk
  sync      Discovers and updates APIs
  version   Version info

total 20K
drwx------ 1 root root 4.0K Aug  3 16:14 .
drwxr-xr-x 1 root root 4.0K Aug  3 16:14 ..
-rw-r--r-- 1 root root  570 Jan 31  2010 .bashrc
drwxr-xr-x 3 root root 4.0K Aug  3 16:14 .cmk
-rw-r--r-- 1 root root  148 Aug 17  2015 .profile
Removing intermediate container cd3733adeb8f
 ---> 125b11055256
Successfully built 125b11055256
```
