### PR TITLE
Fix mapping of default output type to json

### DIFF
--- a/cmd/output.go
+++ b/cmd/output.go
@@ -254,6 +254,8 @@ func printResult(outputType string, response map[string]interface{}, filter []st
 		printCsv(response, filter)
 	case config.TABLE:
 		printTable(response, filter)
+	case config.DEFAULT:
+		printJSON(response)
 	default:
 		fmt.Println("Invalid output type configured, please fix that!")
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -40,6 +40,7 @@ const (
 	JSON   = "json"
 	TABLE  = "table"
 	TEXT   = "text"
+	DEFAULT= "default"
 )
 
 // ServerProfile describes a management server
@@ -75,7 +76,7 @@ type Config struct {
 }
 
 func GetOutputFormats() []string {
- return []string {"column", "csv", "json", "table", "text"}
+ return []string {"column", "csv", "json", "table", "text", "default"}
 }
 
 func CheckIfValuePresent(dataset []string, element string) bool {


### PR DESCRIPTION
Fixes: #92 
This PR maps output format "default" to "json"
#### Prior Fix:
```
// Prevents setting default as an output type
go run cmk.go set output default
🙈 Error: Invalid value set for output. Supported values: column, csv, json, table, text
exit status 1

// Doesn't map "default" output format to a valid display type
go run cmk.go list domains
Invalid output type configured, please fix that!

```

#### Post Fix:
```
$ go run cmk.go set output default
$ go run cmk.go list domains
{
  "count": 1,
  "domain": [
    {
      "cpuavailable": "Unlimited",
      "cpulimit": "Unlimited",
      "cputotal": 0,
      ...
      }
  ]
}


```