### PR TITLE
Display output in human readable format

### DIFF
--- a/cmd/output.go
+++ b/cmd/output.go
@@ -46,7 +46,12 @@ func jsonify(value interface{}, format string) string {
 			value = string(jsonStr)
 		}
 	}
-	return fmt.Sprintf("%v", value)
+	switch value.(type) {
+	case float64, float32:
+		return fmt.Sprintf("%.f", value)
+	default:
+		return fmt.Sprintf("%v", value)
+	}
 }
 
 func printJSON(response map[string]interface{}) {


### PR DESCRIPTION
Fixes: https://github.com/apache/cloudstack-cloudmonkey/issues/94
When output format is set to anything other than JSON, it is observed that large values for example, size, etc are represented in scientific format. This PR ensures consistency in representing such values in the output between JSON and other formats, by displaying them in human readable format.

Prior Fix:
```
(primateqa) 🐱 > set output table
(primateqa) 🐱 > list snapshots id=087937b3-eb30-4c22-8ad5-46067a628699 filter=virtualsize,
count = 1
snapshot:
+-----------------+
|   VIRTUALSIZE   |
+-----------------+
| 2.147483648e+10 |
+-----------------+

or 

(primateqa) 🐱 > list volumes id=002c3dd3-fc4c-4b1e-82e2-2a4b851b207d  filter=size,
count = 1
volume:
+-----------------+
|      SIZE       |
+-----------------+
| 1.073741824e+11 |
+-----------------+

```

Post Fix:
```
(primate) 🐱 > set output text
(primate) 🐱 > list snapshots id=087937b3-eb30-4c22-8ad5-46067a628699  filter=virtualsize,
snapshot:
virtualsize = 21474836480


(primate) 🐱 > list snapshots id=087937b3-eb30-4c22-8ad5-46067a628699  filter=virtualsize,
count = 1
snapshot:
+-------------+
| VIRTUALSIZE |
+-------------+
| 21474836480 |
+-------------+

OR

(primate) 🐱 > list volumes id=002c3dd3-fc4c-4b1e-82e2-2a4b851b207d  filter=size,
count = 1
volume:
+--------------+
|     SIZE     |
+--------------+
| 107374182400 |
+--------------+

```

