### PR TITLE
show meaningful metadata for id autocompletion in some cases

### DIFF
--- a/cli/completer.go
+++ b/cli/completer.go
@@ -129,6 +129,8 @@ func buildArgOptions(response map[string]interface{}, hasID bool) []argOption {
 					name = resource["name"].(string)
 				} else if resource["username"] != nil {
 					name = resource["username"].(string)
+				} else if resource["hypervisor"] != nil && resource["hypervisorversion"] != nil {
+					name = fmt.Sprintf("%s %s", resource["hypervisor"].(string), resource["hypervisorversion"].(string))
 				}
 				if resource["displaytext"] != nil {
 					detail = resource["displaytext"].(string)

--- a/cli/completer.go
+++ b/cli/completer.go
@@ -131,6 +131,9 @@ func buildArgOptions(response map[string]interface{}, hasID bool) []argOption {
 					name = resource["username"].(string)
 				} else if resource["hypervisor"] != nil && resource["hypervisorversion"] != nil {
 					name = fmt.Sprintf("%s %s", resource["hypervisor"].(string), resource["hypervisorversion"].(string))
+					if resource["osdisplayname"] != nil {
+						name = fmt.Sprintf("%s; %s", resource["osdisplayname"].(string), name)
+					}
 				}
 				if resource["displaytext"] != nil {
 					detail = resource["displaytext"].(string)


### PR DESCRIPTION
Shows hypervisor and its version while listing IDs for auto-completion for `listHypervisorCapabilities` API

Before change:
![Screenshot from 2021-09-20 13-10-09](https://user-images.githubusercontent.com/153340/133969972-c527f53e-4425-44a5-bf19-f11a5bb4844c.png)

![Screenshot from 2021-09-20 13-49-50](https://user-images.githubusercontent.com/153340/133973964-3b006f84-8731-48fb-95e8-a5fa1e6ec09a.png)



After change:
![Screenshot from 2021-09-20 13-10-56](https://user-images.githubusercontent.com/153340/133970022-a2010361-0861-4d39-9fa8-4a74e78ea187.png)


![Screenshot from 2021-09-20 13-50-54](https://user-images.githubusercontent.com/153340/133973980-9dab1ce5-fbd7-43cf-a430-4aab45b199f7.png)


