### PR TITLE
Fixed typo in command.go

### DIFF
--- a/cmd/command.go
+++ b/cmd/command.go
@@ -68,7 +68,7 @@ Allowed flags:
   -o        API response output format: json, text, table, column, csv
   -p        Server profile
   -d        Enable debug mode
-  -c        different config file path
+  -c        Different config file path
 
 Default commands:
 %s


### PR DESCRIPTION
Hey there,
I noticed a capitalization issue in the following output. This pr will fix it.

```
root@dev ~/desktop/cloudmonkey [typo]$ ./bin/cmk -h
...

Allowed flags:
  -h        Show this help message or API doc when specified after an API
  -v        Print version
  -o        API response output format: json, text, table, column, csv
  -p        Server profile
  -d        Enable debug mode
  -c        different config file path

...
```