### PR TITLE
Prevent incorrect timeout value from being set

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -321,6 +321,7 @@ func (c *Config) UpdateConfig(key string, value string, update bool) {
 		intValue, err := strconv.Atoi(value)
 		if err != nil {
 			fmt.Println("Error caught while setting timeout:", err)
+			return
 		}
 		c.Core.Timeout = intValue
 	case "profile":


### PR DESCRIPTION
Fixes #100 / https://github.com/apache/cloudstack-cloudmonkey/issues/102

```
(test) 🐱 > set timeout 
Error caught while setting timeout: strconv.Atoi: parsing "": invalid syntax
(test) 🐱 > 
(test) 🐱 > create project name=dummy1 displaytext=dummy1
{
  "project": {
    "cpuavailable": "40",
    "cpulimit": "40",
    "cputotal": 0,
    "created": "2021-09-30T16:13:24+0000",
    "displaytext": "dummy1",
  }
}

(test) 🐱 > set timeout test
Error caught while setting timeout: strconv.Atoi: parsing "test": invalid syntax
(test) 🐱 > 
(test) 🐱 > create project name=dummy2 displaytext=dummy2
{
  "project": {
    "cpuavailable": "40",
    "cpulimit": "40",
    "cputotal": 0,
    "created": "2021-09-30T16:14:07+0000",
    "displaytext": "dummy2",
    "domain": "ROOT",
...
  }
}
```