### PR TITLE
fix: reuse cmk's CLI params to call piped cmd

### DIFF
--- a/cli/exec.go
+++ b/cli/exec.go
@@ -40,7 +40,8 @@ func ExecLine(line string) error {
 	if runtime.GOOS != "windows" {
 		for _, arg := range args {
 			if arg == "|" {
-				result, err := exec.Command("bash", "-c", fmt.Sprintf("%s %v", os.Args[0], line)).Output()
+				fullCommand := fmt.Sprintf("%s %v", strings.Join(os.Args, " "), line)
+				result, err := exec.Command("bash", "-c", fullCommand).Output()
 				fmt.Print(string(result))
 				return err
 			}


### PR DESCRIPTION
This fix makes possible to call piped commands in the `cmk`'s prompt when using a profile else than default one. 

---

Before this patch, we got a weird error while calling any piped command from a session started with a different profile (passed from command line parameters).
```
% cmk -p my-example-profile -o json
Apache CloudStack 🐵 CloudMonkey 6.2.0
Report issues: https://github.com/apache/cloudstack-cloudmonkey/issues

(my-example-profile) 🐱 > list projects | jq -r '.project[].name'
🙈 Error: exit status 4
```

After this one we got the right output:
```
% cmk-patched -p my-example-profile -o json
Apache CloudStack 🐵 CloudMonkey 6.2.0
Report issues: https://github.com/apache/cloudstack-cloudmonkey/issues

(my-example-profile) 🐱 > list projects | jq -r '.project[].name'
project01
project02
```