### PR TITLE
Fix #115: cmk ignores the CLI profile arg when loading the cache file

### DIFF
--- a/cmk.go
+++ b/cmk.go
@@ -21,7 +21,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"path"
 	"strings"
 
 	"github.com/apache/cloudstack-cloudmonkey/cli"
@@ -39,17 +38,6 @@ func init() {
 	flag.Usage = func() {
 		cmd.PrintUsage()
 	}
-}
-
-func existsProfileCache(profile string, cfg *config.Config) bool {
-	cacheDir := path.Join(cfg.Dir, "profiles")
-	cacheFileName := profile + ".cache"
-	fileName := path.Join(cacheDir, cacheFileName)
-	info, err := os.Stat(fileName)
-	if os.IsNotExist(err) {
-		return false
-	}
-	return !info.IsDir()
 }
 
 func main() {
@@ -96,12 +84,9 @@ func main() {
 	}
 
 	if *profile != "" {
-		if !existsProfileCache(*profile, cfg) {
-			fmt.Printf("Cannot find a cache file for the profile: %s\n", *profile)
-			os.Exit(1)
-		}
 		cfg.LoadProfile(*profile)
 	}
+	config.LoadCache(cfg)
 
 	if *apiKey != "" && *secretKey != "" {
 		request := cmd.NewRequest(nil, cfg, nil)

--- a/cmk.go
+++ b/cmk.go
@@ -21,6 +21,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path"
 	"strings"
 
 	"github.com/apache/cloudstack-cloudmonkey/cli"
@@ -38,6 +39,17 @@ func init() {
 	flag.Usage = func() {
 		cmd.PrintUsage()
 	}
+}
+
+func existsProfileCache(profile string, cfg *config.Config) bool {
+	cacheDir := path.Join(cfg.Dir, "profiles")
+	cacheFileName := profile + ".cache"
+	fileName := path.Join(cacheDir, cacheFileName)
+	info, err := os.Stat(fileName)
+	if os.IsNotExist(err) {
+		return false
+	}
+	return !info.IsDir()
 }
 
 func main() {
@@ -70,6 +82,10 @@ func main() {
 	}
 
 	if *profile != "" {
+		if !existsProfileCache(*profile, cfg) {
+			fmt.Printf("Cannot find a cache file for the profile: %s\n", *profile)
+			os.Exit(1)
+		}
 		cfg.LoadProfile(*profile)
 	}
 

--- a/config/cache.go
+++ b/config/cache.go
@@ -84,9 +84,7 @@ func LoadCache(c *Config) interface{} {
 	Debug("Trying to read API cache from:", cacheFile)
 	cache, err := ioutil.ReadFile(cacheFile)
 	if err != nil {
-		if c.HasShell {
-			fmt.Fprintf(os.Stderr, "Loaded in-built API cache. Failed to read API cache, please run 'sync'.\n")
-		}
+		fmt.Fprintf(os.Stderr, "Loaded in-built API cache. Failed to read API cache, please run 'sync'.\n")
 		cache = []byte(preCache)
 	}
 	var data map[string]interface{}

--- a/config/config.go
+++ b/config/config.go
@@ -200,7 +200,7 @@ func setActiveProfile(cfg *Config, profile *ServerProfile) {
 	cfg.ActiveProfile.Client = newHTTPClient(cfg)
 }
 
-func reloadConfig(cfg *Config) *Config {
+func reloadConfig(cfg *Config, loadCache bool) *Config {
 	fileLock := flock.New(path.Join(getDefaultConfigDir(), "lock"))
 	err := fileLock.Lock()
 	if err != nil {
@@ -209,7 +209,9 @@ func reloadConfig(cfg *Config) *Config {
 	}
 	cfg = saveConfig(cfg)
 	fileLock.Unlock()
-	LoadCache(cfg)
+	if loadCache {
+		LoadCache(cfg)
+	}
 	return cfg
 }
 
@@ -360,7 +362,7 @@ func (c *Config) UpdateConfig(key string, value string, update bool) {
 	Debug("UpdateConfig key:", key, " value:", value, " update:", update)
 
 	if update {
-		reloadConfig(c)
+		reloadConfig(c, true)
 	}
 }
 
@@ -376,7 +378,6 @@ func NewConfig(configFilePath *string) *Config {
 			os.Exit(1)
 		}
 	}
-	cfg := reloadConfig(defaultConf)
-	LoadCache(cfg)
+	cfg := reloadConfig(defaultConf, false)
 	return cfg
 }


### PR DESCRIPTION
Fixes: #115 

### Tests

````
$ ls ~/.cmk/profiles/
labenv.cache      localcloud.cache
$ grep profile ~/.cmk/config
profile      = 
````

- Load the cache file if the profile configuration is empty

````
$ ./bin/cmk -p labenv list tungstenfabricproviders
$
````

- Load the built-in API cache if there is no cache file for the profile:

````
$ ./bin/cmk -p vmware list tungstenfabricproviders
Loaded in-built API cache. Failed to read API cache, please run 'sync'.
🙈 Error: unknown command or API requested
````