### PR TITLE
network: when using API key & secret key drop params

### DIFF
--- a/cmd/network.go
+++ b/cmd/network.go
@@ -221,6 +221,7 @@ func NewAPIRequest(r *Request, api string, args []string, isAsync bool) (map[str
 		mac.Write([]byte(strings.ToLower(encodedParams)))
 		signature := base64.StdEncoding.EncodeToString(mac.Sum(nil))
 		encodedParams = encodedParams + fmt.Sprintf("&signature=%s", url.QueryEscape(signature))
+		params = nil
 	} else if len(r.Config.ActiveProfile.Username) > 0 && len(r.Config.ActiveProfile.Password) > 0 {
 		sessionKey, err := Login(r)
 		if err != nil {


### PR DESCRIPTION
Params need to be dropped as apikey & secretkey based URL has all the params and it causes signature validation issues when the same params are also posted again. For example, add host API with username, password params.