### PR TITLE
List free IPs when performing associate IPAddress operation

### DIFF
--- a/cli/completer.go
+++ b/cli/completer.go
@@ -200,6 +200,7 @@ func findAutocompleteAPI(arg *config.APIArg, apiFound *config.API, apiMap map[st
 	if arg.Type == "map" {
 		return nil
 	}
+	config.Debug("PEARL apiFound: ", apiFound)
 
 	var autocompleteAPI *config.API
 	argName := strings.Replace(arg.Name, "=", "", -1)
@@ -374,6 +375,7 @@ func (t *autoCompleter) Do(line []rune, pos int) (options [][]rune, offset int) 
 			}
 
 			autocompleteAPI := findAutocompleteAPI(arg, apiFound, apiMap)
+			config.Debug("api: ", autocompleteAPI)
 			if autocompleteAPI == nil {
 				return nil, 0
 			}
@@ -391,6 +393,8 @@ func (t *autoCompleter) Do(line []rune, pos int) (options [][]rune, offset int) 
 					autocompleteAPIArgs = append(autocompleteAPIArgs, "type=Routing")
 				} else if apiFound.Name == "migrateSystemVm" {
 					autocompleteAPI.Name = "listSystemVms"
+				} else if apiFound.Name == "associateIpAddress" {
+					autocompleteAPIArgs = append(autocompleteAPIArgs, "state=Free")
 				}
 
 				spinner := t.Config.StartSpinner("fetching options, please wait...")

--- a/cli/completer.go
+++ b/cli/completer.go
@@ -200,7 +200,6 @@ func findAutocompleteAPI(arg *config.APIArg, apiFound *config.API, apiMap map[st
 	if arg.Type == "map" {
 		return nil
 	}
-	config.Debug("PEARL apiFound: ", apiFound)
 
 	var autocompleteAPI *config.API
 	argName := strings.Replace(arg.Name, "=", "", -1)
@@ -375,7 +374,6 @@ func (t *autoCompleter) Do(line []rune, pos int) (options [][]rune, offset int) 
 			}
 
 			autocompleteAPI := findAutocompleteAPI(arg, apiFound, apiMap)
-			config.Debug("api: ", autocompleteAPI)
 			if autocompleteAPI == nil {
 				return nil, 0
 			}


### PR DESCRIPTION
This PR list free IPs as opposed to the allocated IPs when trying associate an IP to a network

### Before fix:
![image](https://github.com/user-attachments/assets/ae78fa75-251b-45e9-9fe7-705765b5f497)

which are the list of allocated IPs:
![image](https://github.com/user-attachments/assets/d3d14347-04c5-448b-8ed9-a7f07a88ace0)

### After fix:
![image](https://github.com/user-attachments/assets/1b3f531f-4f3e-4feb-9f7c-03aa94ec0c35)
