### PR TITLE
Fix usagetype parameter autocomplete

### DIFF
--- a/cli/completer.go
+++ b/cli/completer.go
@@ -20,6 +20,7 @@ package cli
 import (
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"unicode"
 
@@ -123,7 +124,14 @@ func buildArgOptions(response map[string]interface{}, hasID bool) []argOption {
 				}
 				var id, name, detail string
 				if resource["id"] != nil {
-					id = resource["id"].(string)
+					switch rawId := resource["id"].(type) {
+					case string:
+						id = rawId
+					case float64:
+						id = strconv.FormatFloat(rawId, 'f', -1, 64)
+					default:
+						panic(fmt.Errorf("detected an invalid type at path (%v:%T). This should have been caught during validation, indicating a bug in CloudMonkey. Please report this issue", rawId, rawId))
+					}
 				}
 				if resource["name"] != nil {
 					name = resource["name"].(string)
@@ -398,15 +406,23 @@ func (t *autoCompleter) Do(line []rune, pos int) (options [][]rune, offset int) 
 				response, _ := cmd.NewAPIRequest(request, autocompleteAPI.Name, autocompleteAPIArgs, false)
 				t.Config.StopSpinner(spinner)
 
-				hasID := strings.HasSuffix(arg.Name, "id=") || strings.HasSuffix(arg.Name, "ids=")
+				hasID := strings.HasSuffix(arg.Name, "id=") || strings.HasSuffix(arg.Name, "ids=") || autocompleteAPI.Name == "listUsageTypes"
 				argOptions = buildArgOptions(response, hasID)
 			}
 
 			filteredOptions := []argOption{}
 			if len(argOptions) > 0 {
-				sort.Slice(argOptions, func(i, j int) bool {
-					return argOptions[i].Value < argOptions[j].Value
-				})
+				if isNumeric(argOptions[0].Value) {
+					sort.Slice(argOptions, func(i, j int) bool {
+						i, _ = strconv.Atoi(argOptions[i].Value)
+						j, _ = strconv.Atoi(argOptions[j].Value)
+						return i < j
+					})
+				} else {
+					sort.Slice(argOptions, func(i, j int) bool {
+						return argOptions[i].Value < argOptions[j].Value
+					})
+				}
 				for _, item := range argOptions {
 					if strings.HasPrefix(item.Value, argInput) {
 						filteredOptions = append(filteredOptions, item)
@@ -432,4 +448,13 @@ func (t *autoCompleter) Do(line []rune, pos int) (options [][]rune, offset int) 
 	}
 
 	return options, offset
+}
+
+func isNumeric(str string) bool {
+	for _, char := range str {
+		if !unicode.IsDigit(char) {
+			return false
+		}
+	}
+	return true
 }

--- a/cli/completer.go
+++ b/cli/completer.go
@@ -412,7 +412,7 @@ func (t *autoCompleter) Do(line []rune, pos int) (options [][]rune, offset int) 
 
 			filteredOptions := []argOption{}
 			if len(argOptions) > 0 {
-				if isNumeric(argOptions[0].Value) {
+				if autocompleteAPI.Name == "listUsageTypes" {
 					sort.Slice(argOptions, func(i, j int) bool {
 						i, _ = strconv.Atoi(argOptions[i].Value)
 						j, _ = strconv.Atoi(argOptions[j].Value)
@@ -448,13 +448,4 @@ func (t *autoCompleter) Do(line []rune, pos int) (options [][]rune, offset int) 
 	}
 
 	return options, offset
-}
-
-func isNumeric(str string) bool {
-	for _, char := range str {
-		if !unicode.IsDigit(char) {
-			return false
-		}
-	}
-	return true
 }


### PR DESCRIPTION
Currently, when using autocomplete in the `usagetype` parameter (present in APIs such as `quotaPresetVariableList` and `quotaCreateTariff`) the CLI panics.

```
$ cmk  
Apache CloudStack 🐵 CloudMonkey 6.4.0
Report issues: https://github.com/apache/cloudstack-cloudmonkey/issues

panic: interface conversion: interface {} is float64, not string

goroutine 36 [running]:
github.com/apache/cloudstack-cloudmonkey/cli.buildArgOptions(0xc000f48000?, 0x0)
	/Users/rohit/lab/apache/cloudstack-cloudmonkey/cli/completer.go:126 +0x8c5
github.com/apache/cloudstack-cloudmonkey/cli.(*autoCompleter).Do(0xc00004f790, {0xc000e9e3f0, 0x0?, 0x24}, 0x24)
	/Users/rohit/lab/apache/cloudstack-cloudmonkey/cli/completer.go:402 +0x136c
github.com/chzyer/readline.(*opCompleter).OnComplete(0xc000130ee0)
	/Users/rohit/lab/apache/cloudstack-cloudmonkey/vendor/github.com/chzyer/readline/complete.go:101 +0x10d
github.com/chzyer/readline.(*Operation).ioloop(0xc000130e00)
	/Users/rohit/lab/apache/cloudstack-cloudmonkey/vendor/github.com/chzyer/readline/operation.go:180 +0xc8a
created by github.com/chzyer/readline.NewOperation in goroutine 1
	/Users/rohit/lab/apache/cloudstack-cloudmonkey/vendor/github.com/chzyer/readline/operation.go:88 +0x2d6
```

This PR aims to fix this bug and allow users to use the completer for the `usagetype` parameter.

![Screenshot from 2025-01-01 15-30-09](https://github.com/user-attachments/assets/d44598bb-fd2f-42db-92f1-10209b16c98b)