### PR TITLE
Fix autocomplete of migrateSystemVm

### DIFF
--- a/cli/completer.go
+++ b/cli/completer.go
@@ -389,7 +389,7 @@ func (t *autoCompleter) Do(line []rune, pos int) (options [][]rune, offset int) 
 
 				if apiFound.Name != "provisionCertificate" && autocompleteAPI.Name == "listHosts" {
 					autocompleteAPIArgs = append(autocompleteAPIArgs, "type=Routing")
-				} else if apiFound.Name == "migrateSystemVm" {
+				} else if apiFound.Name == "migrateSystemVm" && autocompleteAPI.Name == "listVirtualMachines" {
 					autocompleteAPI.Name = "listSystemVms"
 				}
 


### PR DESCRIPTION
### Description

Right now, the autocomplete of the `storageid` parameter on the `migrateSystemVm` API is returning system VMs IDs instead of the expected storage IDs, as shown below. This bug also sets the CloudMonkey autocomplete cache for others APIs, such as `migrateVirtualMachine`.

```
Apache CloudStack 🐵 CloudMonkey 6.4.0
Report issues: https://github.com/apache/cloudstack-cloudmonkey/issues

(localcloud) 🐱 > migrate systemvm storageid=
0124fcb6-ca16-421e-b332-d1438f63ac5a (v-12-VM)     159e8d32-5f74-41b1-ba17-8b0e734143f0 (s-14-VM)   
(localcloud) 🐱 > migrate virtualmachine storageid=
0124fcb6-ca16-421e-b332-d1438f63ac5a (v-12-VM)     159e8d32-5f74-41b1-ba17-8b0e734143f0 (s-14-VM)    

``` 

This PR corrects this behavior by adding a verification so that the `autocompleteAPI` struct only changes its `Name` member to `listSystemVms` when it's defined to `listVirtualMachines`, thus not calling the `listSystemVms` API to autocomplete the `storageid` parameter. 

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor


### How Has This Been Tested?

On CloudMonkey the autocomplete of all parameters in `migrateSystemVm` was called, and verified to be the correct answer, as shown below.

```
Apache CloudStack 🐵 CloudMonkey 6.4.0
Report issues: https://github.com/apache/cloudstack-cloudmonkey/issues

(localcloud) 🐱 > migrate systemvm storageid=
10d65800-bbda-347a-bbb0-250e6d7d1586 (nfs-1)                          817d7155-a725-4cf7-b2bb-bc14b238eb4a (iscsi-1)       
(localcloud) 🐱 > migrate systemvm virtualmachineid=
0124fcb6-ca16-421e-b332-d1438f63ac5a (v-12-VM)                        159e8d32-5f74-41b1-ba17-8b0e734143f0 (s-14-VM)      

```