### PR TITLE
Add autocomplete support for the `instanceid` parameter

### DIFF
--- a/cli/completer.go
+++ b/cli/completer.go
@@ -221,6 +221,8 @@ func findAutocompleteAPI(arg *config.APIArg, apiFound *config.API, apiMap map[st
 		relatedNoun = "storagepools"
 	case argName == "associatednetworkid":
 		relatedNoun = "networks"
+	case argName == "instanceid":
+		relatedNoun = "virtualmachines"
 	default:
 		// Heuristic: autocomplete for the arg for which a list<Arg without id/ids>s API exists
 		// For example, for zoneid arg, listZones API exists


### PR DESCRIPTION
### Description

The PR https://github.com/apache/cloudstack/pull/11016 introduces the `listConsoleSessions` API, which accepts  the `instanceid` parameter, that represents the ID of the VM associated with the console session.

However, currently, Apache Cloudstack Cloudmonkey does not support autocomplete for this parameter. Therefore, this PR adds autocomplete support for it.

### How Has This Been Tested?

- Executed the `listConsoleSessions` API and verified that Apache CloudStack Cloudmonkey is correctly autocompleting the `instanceid` parameter 