### PR TITLE
Add support for excluding a list of parameters from an API response

### DIFF
--- a/cli/completer.go
+++ b/cli/completer.go
@@ -357,6 +357,7 @@ func (t *autoCompleter) Do(line []rune, pos int) (options [][]rune, offset int) 
 				}
 				return
 			}
+
 			if arg.Type == config.FAKE && arg.Name == "filter=" {
 				offset = 0
 				filterInputs := strings.Split(strings.Replace(argInput, ",", ",|", -1), "|")
@@ -368,6 +369,22 @@ func (t *autoCompleter) Do(line []rune, pos int) (options [][]rune, offset int) 
 					if strings.HasPrefix(key, lastFilterInput) {
 						options = append(options, []rune(key[len(lastFilterInput):]))
 						offset = len(lastFilterInput)
+					}
+				}
+				return
+			}
+
+			if arg.Type == config.FAKE && arg.Name == "exclude=" {
+				offset = 0
+				excludeFilterInputs := strings.Split(strings.Replace(argInput, ",", ",|", -1), "|")
+				lastExcludeFilterInput := lastString(excludeFilterInputs)
+				for _, key := range apiFound.ResponseKeys {
+					if inArray(key, excludeFilterInputs) {
+						continue
+					}
+					if strings.HasPrefix(key, lastExcludeFilterInput) {
+						options = append(options, []rune(key[len(lastExcludeFilterInput):]))
+						offset = len(lastExcludeFilterInput)
 					}
 				}
 				return

--- a/cmd/api.go
+++ b/cmd/api.go
@@ -82,7 +82,7 @@ func init() {
 				if strings.HasSuffix(err.Error(), "context canceled") {
 					return nil
 				} else if response != nil {
-					printResult(r.Config.Core.Output, response, nil)
+					printResult(r.Config.Core.Output, response, nil, nil)
 				}
 				return err
 			}
@@ -98,8 +98,19 @@ func init() {
 				}
 			}
 
+			var excludeKeys []string
+			for _, arg := range apiArgs {
+				if strings.HasPrefix(arg, "exclude=") {
+					for _, excludeKey := range strings.Split(strings.Split(arg, "=")[1], ",") {
+						if len(strings.TrimSpace(excludeKey)) > 0 {
+							excludeKeys = append(excludeKeys, strings.TrimSpace(excludeKey))
+						}
+					}
+				}
+			}
+
 			if len(response) > 0 {
-				printResult(r.Config.Core.Output, response, filterKeys)
+				printResult(r.Config.Core.Output, response, filterKeys, excludeKeys)
 			}
 
 			return nil

--- a/config/cache.go
+++ b/config/cache.go
@@ -151,6 +151,13 @@ func (c *Config) UpdateCache(response map[string]interface{}) interface{} {
 			Description: "cloudmonkey specific response key filtering",
 		})
 
+		// Add exclude arg
+		apiArgs = append(apiArgs, &APIArg{
+			Name:        "exclude=",
+			Type:        FAKE,
+			Description: "cloudmonkey specific response key to exlude when filtering",
+		})
+
 		sort.Slice(apiArgs, func(i, j int) bool {
 			return apiArgs[i].Name < apiArgs[j].Name
 		})


### PR DESCRIPTION
This PR address #https://github.com/apache/cloudstack-cloudmonkey/issues/149, it adds an exclude parameter to remove fields from the response

For example, without the exclude parameter, the listAccounts response looks like:

```
$ ./cmk -p pd-env list accounts name=admin
{
  "account": [
    {
      "accounttype": 1,
      "apikeyaccess": "INHERIT",
      "backupavailable": "Unlimited",
      "backuplimit": "Unlimited",
      "backupstorageavailable": "Unlimited",
      "backupstoragelimit": "Unlimited",
      "backupstoragetotal": 0,
      "backuptotal": 0,
      "bucketavailable": "Unlimited",
      "bucketlimit": "Unlimited",
      "buckettotal": 0,
      "cpuavailable": "Unlimited",
      "cpulimit": "Unlimited",
      "cputotal": 4,
      "domain": "ROOT",
      "domainid": "db0704ab-5827-11f0-804a-1e0052000469",
      "domainpath": "ROOT",
      "groups": [],
      "id": "24e85a59-5828-11f0-804a-1e0052000469",
      "ipavailable": "Unlimited",
      "iplimit": "Unlimited",
      "iptotal": 1,
      "isdefault": true,
      "memoryavailable": "Unlimited",
      "memorylimit": "Unlimited",
      "memorytotal": 4096,
      "name": "admin",
      "networkavailable": "Unlimited",
      "networklimit": "Unlimited",
      "networktotal": 1,
      "objectstorageavailable": "Unlimited",
      "objectstoragelimit": "Unlimited",
      "objectstoragetotal": 0,
      "primarystorageavailable": "Unlimited",
      "primarystoragelimit": "Unlimited",
      "primarystoragetotal": 16,
      "projectavailable": "Unlimited",
      "projectlimit": "Unlimited",
      "projecttotal": 0,
      "receivedbytes": 1346690740,
      "roleid": "fff4ee8f-5827-11f0-804a-1e0052000469",
      "rolename": "Root Admin",
      "roletype": "Admin",
      "secondarystorageavailable": "Unlimited",
      "secondarystoragelimit": "Unlimited",
      "secondarystoragetotal": 0,
      "sentbytes": 35867842,
      "snapshotavailable": "Unlimited",
      "snapshotlimit": "Unlimited",
      "snapshottotal": 0,
      "state": "enabled",
      "templateavailable": "Unlimited",
      "templatelimit": "Unlimited",
      "templatetotal": 0,
      "user": [
        {
          "account": "admin",
          "accountid": "24e85a59-5828-11f0-804a-1e0052000469",
          "accounttype": 1,
          "apikey": "LIN6rqXuaJwMPfGYFh13qDwYz5VNNz1J2J6qIOWcd3oLQOq0WtD4CwRundBL6rzXToa3lQOC_vKjI3nkHtiD8Q",
          "created": "2025-07-03T16:09:48+0000",
          "domain": "ROOT",
          "domainid": "db0704ab-5827-11f0-804a-1e0052000469",
          "firstname": "admin",
          "id": "24e902f0-5828-11f0-804a-1e0052000469",
          "is2faenabled": false,
          "is2famandated": false,
          "iscallerchilddomain": false,
          "isdefault": true,
          "lastname": "cloud",
          "roleid": "fff4ee8f-5827-11f0-804a-1e0052000469",
          "rolename": "Root Admin",
          "roletype": "Admin",
          "state": "enabled",
          "username": "admin",
          "usersource": "native"
        },
        {
          "account": "admin",
          "accountid": "24e85a59-5828-11f0-804a-1e0052000469",
          "accounttype": 1,
          "apikey": "U7qz8y6CjK1ECQsOuRLT7XaIfaWF3QuB4VJBHvDOBfQjyzsVvhWgDhMkHveJzu1Bb7oFnYKG4CZAfdHLpnim6w",
          "created": "2025-07-09T17:26:05+0000",
          "domain": "ROOT",
          "domainid": "db0704ab-5827-11f0-804a-1e0052000469",
          "email": "kubeadmin",
          "firstname": "admin",
          "id": "8ea65043-7df2-4906-8953-641a7e25a5cf",
          "is2faenabled": false,
          "is2famandated": false,
          "iscallerchilddomain": false,
          "isdefault": false,
          "lastname": "kubeadmin",
          "roleid": "fff4ee8f-5827-11f0-804a-1e0052000469",
          "rolename": "Root Admin",
          "roletype": "Admin",
          "state": "enabled",
          "username": "admin-kubeadmin",
          "usersource": "native"
        }
      ],
      "vmavailable": "Unlimited",
      "vmlimit": "Unlimited",
      "vmrunning": 2,
      "vmstopped": 0,
      "vmtotal": 2,
      "volumeavailable": "Unlimited",
      "volumelimit": "Unlimited",
      "volumetotal": 2,
      "vpcavailable": "Unlimited",
      "vpclimit": "Unlimited",
      "vpctotal": 0
    }
  ],
  "count": 1
}

```

With this patch, if user wants to remove `user` field from the response, they could do so using the exclude param:
```
$ ./cmk -p pd-env list accounts name=admin exclude=user
{
  "account": [
    {
      "accounttype": 1,
      "apikeyaccess": "INHERIT",
      "backupavailable": "Unlimited",
      "backuplimit": "Unlimited",
      "backupstorageavailable": "Unlimited",
      "backupstoragelimit": "Unlimited",
      "backupstoragetotal": 0,
      "backuptotal": 0,
      "bucketavailable": "Unlimited",
      "bucketlimit": "Unlimited",
      "buckettotal": 0,
      "cpuavailable": "Unlimited",
      "cpulimit": "Unlimited",
      "cputotal": 4,
      "domain": "ROOT",
      "domainid": "db0704ab-5827-11f0-804a-1e0052000469",
      "domainpath": "ROOT",
      "groups": [],
      "id": "24e85a59-5828-11f0-804a-1e0052000469",
      "ipavailable": "Unlimited",
      "iplimit": "Unlimited",
      "iptotal": 1,
      "isdefault": true,
      "memoryavailable": "Unlimited",
      "memorylimit": "Unlimited",
      "memorytotal": 4096,
      "name": "admin",
      "networkavailable": "Unlimited",
      "networklimit": "Unlimited",
      "networktotal": 1,
      "objectstorageavailable": "Unlimited",
      "objectstoragelimit": "Unlimited",
      "objectstoragetotal": 0,
      "primarystorageavailable": "Unlimited",
      "primarystoragelimit": "Unlimited",
      "primarystoragetotal": 16,
      "projectavailable": "Unlimited",
      "projectlimit": "Unlimited",
      "projecttotal": 0,
      "receivedbytes": 1346706148,
      "roleid": "fff4ee8f-5827-11f0-804a-1e0052000469",
      "rolename": "Root Admin",
      "roletype": "Admin",
      "secondarystorageavailable": "Unlimited",
      "secondarystoragelimit": "Unlimited",
      "secondarystoragetotal": 0,
      "sentbytes": 35872906,
      "snapshotavailable": "Unlimited",
      "snapshotlimit": "Unlimited",
      "snapshottotal": 0,
      "state": "enabled",
      "templateavailable": "Unlimited",
      "templatelimit": "Unlimited",
      "templatetotal": 0,
      "vmavailable": "Unlimited",
      "vmlimit": "Unlimited",
      "vmrunning": 2,
      "vmstopped": 0,
      "vmtotal": 2,
      "volumeavailable": "Unlimited",
      "volumelimit": "Unlimited",
      "volumetotal": 2,
      "vpcavailable": "Unlimited",
      "vpclimit": "Unlimited",
      "vpctotal": 0
    }
  ],
  "count": 1
}

```
