### PR TITLE
github-action: lint runner

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,38 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Lint Check
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    name: Run make lint
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+
+      - name: Run lint
+        run: |
+          make lint

--- a/Makefile
+++ b/Makefile
@@ -67,9 +67,12 @@ dist: dist-linux
 
 # Tools
 
+$(BIN):
+	@mkdir -p $(BIN)
+
 GOLINT = $(BIN)/golint
-$(BIN)/golint:  $(BASE) ; $(info $(M) Building golint…)
-	$Q go get github.com/golang/lint/golint
+$(BIN)/golint: | $(BIN) ; $(info $(M) Building golint…)
+	$Q GOBIN=$(BIN) go install golang.org/x/lint/golint@latest
 
 GOCOVMERGE = $(BIN)/gocovmerge
 $(BIN)/gocovmerge: | $(BASE) ; $(info $(M) building gocovmerge…)

--- a/cmd/network.go
+++ b/cmd/network.go
@@ -299,8 +299,7 @@ func executeRequest(r *Request, requestURL string, params url.Values) (*http.Res
 	if params.Has("password") || params.Has("userdata") || r.Config.Core.PostRequest {
 		requestURL = fmt.Sprintf("%s", r.Config.ActiveProfile.URL)
 		return r.Client().PostForm(requestURL, params)
-	} else {
-		req, _ := http.NewRequestWithContext(*r.Config.Context, "GET", requestURL, nil)
-		return r.Client().Do(req)
 	}
+	req, _ := http.NewRequestWithContext(*r.Config.Context, "GET", requestURL, nil)
+	return r.Client().Do(req)
 }

--- a/cmk.go
+++ b/cmk.go
@@ -47,7 +47,7 @@ func main() {
 	debug := flag.Bool("d", false, "enable debug mode")
 	profile := flag.String("p", "", "server profile")
 	configFilePath := flag.String("c", "", "config file path")
-	acsUrl := flag.String("u", config.DEFAULT_ACS_API_ENDPOINT, "cloudStack's API endpoint URL")
+	acsURL := flag.String("u", config.DefaultACSAPIEndpoint, "cloudStack's API endpoint URL")
 	apiKey := flag.String("k", "", "cloudStack user's API Key")
 	secretKey := flag.String("s", "", "cloudStack user's secret Key")
 	flag.Parse()
@@ -72,8 +72,8 @@ func main() {
 		cfg.UpdateConfig("output", *outputFormat, false)
 	}
 
-	if *acsUrl != config.DEFAULT_ACS_API_ENDPOINT {
-		cfg.UpdateConfig("url", *acsUrl, false)
+	if *acsURL != config.DefaultACSAPIEndpoint {
+		cfg.UpdateConfig("url", *acsURL, false)
 	}
 
 	if *apiKey != "" {

--- a/config/config.go
+++ b/config/config.go
@@ -45,7 +45,8 @@ const (
 	DEFAULT = "default"
 )
 
-const DEFAULT_ACS_API_ENDPOINT = "http://localhost:8080/client/api"
+// DefaultACSAPIEndpoint is the default API endpoint for CloudStack.
+const DefaultACSAPIEndpoint = "http://localhost:8080/client/api"
 
 // ServerProfile describes a management server
 type ServerProfile struct {
@@ -84,10 +85,12 @@ type Config struct {
 	C             chan bool
 }
 
+// GetOutputFormats returns the supported output formats.
 func GetOutputFormats() []string {
 	return []string{"column", "csv", "json", "table", "text", "default"}
 }
 
+// CheckIfValuePresent checks if an element is present in the dataset.
 func CheckIfValuePresent(dataset []string, element string) bool {
 	for _, arg := range dataset {
 		if arg == element {
@@ -158,7 +161,7 @@ func defaultCoreConfig() Core {
 
 func defaultProfile() ServerProfile {
 	return ServerProfile{
-		URL:       DEFAULT_ACS_API_ENDPOINT,
+		URL:       DefaultACSAPIEndpoint,
 		Username:  "admin",
 		Password:  "password",
 		Domain:    "/",
@@ -189,6 +192,7 @@ func GetProfiles() []string {
 	return profiles
 }
 
+// SetupContext initializes the context and signal handling for the config.
 func SetupContext(cfg *Config) {
 	cfg.C = make(chan bool)
 	signals := make(chan os.Signal, 1)


### PR DESCRIPTION
Adds a runner for `make lint` with Ubuntu 24.04

Currently, it needs #171 to fix make lint

Tested with https://github.com/shwstppr/cloudstack-cloudmonkey/pull/4