### PR TITLE
autocomplete: list executable isos

### DIFF
--- a/cli/completer.go
+++ b/cli/completer.go
@@ -411,6 +411,9 @@ func (t *autoCompleter) Do(line []rune, pos int) (options [][]rune, offset int) 
 				if autocompleteAPI.Noun == "templates" {
 					autocompleteAPIArgs = append(autocompleteAPIArgs, "templatefilter=executable")
 				}
+				if autocompleteAPI.Noun == "isos" {
+					autocompleteAPIArgs = append(autocompleteAPIArgs, "isofilter=executable")
+				}
 
 				if apiFound.Name != "provisionCertificate" && autocompleteAPI.Name == "listHosts" {
 					autocompleteAPIArgs = append(autocompleteAPIArgs, "type=Routing")


### PR DESCRIPTION
In cmk shell when doing tab to autocomplete for iso id, currently, it returns an empty result. This PR adds isofilter parameter similar to lsit templates call.

Before:
```
⇒  make run                                                                                                                                                                                             main| 
▶  Running gofmt…
▶  Building executable… 9f8ce06
▶  Done!
./bin/cmk
Apache CloudStack 🐵 CloudMonkey 6.4.0
Report issues: https://github.com/apache/cloudstack-cloudmonkey/issues

(test) 🐱 > set debug true
[debug] UpdateConfig key:debug value:true update:true
[debug] Trying to read API cache from:/home/shwstppr/.cmk/profiles/test.cache
(test) 🐱 > list isos id=[debug] Possible related noun for the arg: isos and type: uuid
[debug] Autocomplete: API found using heuristics: listIsos
map[command:[login] domain:[/] password:[password] response:[json] username:[admin]]
[debug] Login POST response status code:200
[debug] Login response body:{"loginresponse":{"username":"admin","userid":"41b07ac1-7731-11f0-9a5b-1e00900003a2","domainid":"f8f8593c-7730-11f0-9a5b-1e00900003a2","timeout":1800,"account":"admin","firstname":"admin","lastname":"cloud","type":"1","timezone":"UTC","timezoneoffset":"0.0","registered":"false","sessionkey":"sCbFNWx_VgaSWCQD8X5CEB8EUxY","is2faenabled":"false","is2faverified":"true","issuerfor2fa":"CloudStack","managementserverid":"7d213c66-5186-4716-9a33-3ee0e63fd6d3"}}
[debug] Login sessionkey:sCbFNWx_VgaSWCQD8X5CEB8EUxY
[debug] Checking if 2FA is enabled and verified for the user map[account:admin domainid:f8f8593c-7730-11f0-9a5b-1e00900003a2 firstname:admin is2faenabled:false is2faverified:true issuerfor2fa:CloudStack lastname:cloud managementserverid:7d213c66-5186-4716-9a33-3ee0e63fd6d3 registered:false sessionkey:sCbFNWx_VgaSWCQD8X5CEB8EUxY timeout:1800 timezone:UTC timezoneoffset:0.0 type:1 userid:41b07ac1-7731-11f0-9a5b-1e00900003a2 username:admin]
[debug] 2FA is not enabled for the user, skipping 2FA validation
[debug] NewAPIRequest API request URL:http://10.0.35.15:8080/client/api?command=listIsos&expires=2025-08-18T12%3A09%3A23Z&listall=true&response=json&sessionkey=sCbFNWx_VgaSWCQD8X5CEB8EUxY&signatureversion=3
⣻ 😽 fetching options, please wait...[debug] NewAPIRequest response status code:200
[debug] NewAPIRequest response body:{"listisosresponse":{}}
(test) 🐱 > list isos id=
```

After:
```
⇒  make run                                                                                                                                                                   autocomp-iso-list| 
▶  Running gofmt…
▶  Building executable… 166f16c
▶  Done!
./bin/cmk
Apache CloudStack 🐵 CloudMonkey 6.4.0
Report issues: https://github.com/apache/cloudstack-cloudmonkey/issues

(test) 🐱 > set debug true
[debug] UpdateConfig key:debug value:true update:true
[debug] Trying to read API cache from:/home/shwstppr/.cmk/profiles/test.cache
(test) 🐱 > list isos id=[debug] Possible related noun for the arg: isos and type: uuid
[debug] Autocomplete: API found using heuristics: listIsos
http://10.0.35.15:8080/client/apimap[command:[login] domain:[/] password:[password] response:[json] username:[admin]]
[debug] Login POST response status code:200
[debug] Login response body:{"loginresponse":{"username":"admin","userid":"41b07ac1-7731-11f0-9a5b-1e00900003a2","domainid":"f8f8593c-7730-11f0-9a5b-1e00900003a2","timeout":1800,"account":"admin","firstname":"admin","lastname":"cloud","type":"1","timezone":"UTC","timezoneoffset":"0.0","registered":"false","sessionkey":"G25Ok9z7jGAgOJh_6_O2pQkxwRM","is2faenabled":"false","is2faverified":"true","issuerfor2fa":"CloudStack","managementserverid":"7d213c66-5186-4716-9a33-3ee0e63fd6d3"}}
[debug] Login sessionkey:G25Ok9z7jGAgOJh_6_O2pQkxwRM
[debug] Checking if 2FA is enabled and verified for the user map[account:admin domainid:f8f8593c-7730-11f0-9a5b-1e00900003a2 firstname:admin is2faenabled:false is2faverified:true issuerfor2fa:CloudStack lastname:cloud managementserverid:7d213c66-5186-4716-9a33-3ee0e63fd6d3 registered:false sessionkey:G25Ok9z7jGAgOJh_6_O2pQkxwRM timeout:1800 timezone:UTC timezoneoffset:0.0 type:1 userid:41b07ac1-7731-11f0-9a5b-1e00900003a2 username:admin]
[debug] 2FA is not enabled for the user, skipping 2FA validation
[debug] NewAPIRequest API request URL:http://10.0.35.15:8080/client/api?command=listIsos&expires=2025-08-18T12%3A10%3A32Z&isofilter=executable&listall=true&response=json&sessionkey=G25Ok9z7jGAgOJh_6_O2pQkxwRM&signatureversion=3
⢿ 😼 fetching options, please wait...[debug] NewAPIRequest response status code:200
[debug] NewAPIRequest response body:{"listisosresponse":{"count":5,"iso":[{"id":"c2e22f89-98c1-4fcb-9d0b-362035a8db04","name":"vmware-tools.iso","displaytext":"VMware Tools Installer ISO","ispublic":true,"isready":true,"passwordenabled":false,"format":"ISO","bootable":false,"isfeatured":true,"crossZones":false,"ostypeid":"f911fa47-7730-11f0-9a5b-1e00900003a2","ostypename":"CentOS 4.5 (32-bit)","account":"system","domain":"ROOT","domainpath":"/","domainid":"f8f8593c-7730-11f0-9a5b-1e00900003a2","isextractable":false,"downloaddetails":[],"arch":"x86_64","bits":64,"isdynamicallyscalable":false,"directdownload":false,"tags":[],"hasannotations":false},{"id":"d5cdaff5-bb7c-4a7f-967a-71af603e8da3","name":"vmware2-tools.iso","displaytext":"vmware2-tools.iso","ispublic":true,"isready":true,"passwordenabled":false,"format":"ISO","bootable":false,"isfeatured":true,"crossZones":false,"ostypeid":"f911fa47-7730-11f0-9a5b-1e00900003a2","ostypename":"CentOS 4.5 (32-bit)","account":"system","domain":"ROOT","domainpath":"/","domainid":"f8f8593c-7730-11f0-9a5b-1e00900003a2","isextractable":false,"downloaddetails":[],"arch":"x86_64","bits":64,"isdynamicallyscalable":false,"directdownload":false,"tags":[],"hasannotations":false},{"id":"82393839-d239-434e-8745-0d24c0f58ee0","name":"v1.33.1-Kubernetes-Binaries-ISO","displaytext":"v1.33.1-Kubernetes-Binaries-ISO","ispublic":true,"created":"2025-08-12T12:25:00+0000","isready":true,"passwordenabled":false,"format":"ISO","bootable":false,"isfeatured":false,"crossZones":true,"ostypeid":"f9363171-7730-11f0-9a5b-1e00900003a2","ostypename":"None","account":"system","zoneid":"5ae50b9f-6280-4c4b-9551-ee48da867034","zonename":"ref-trl-9219-k-Mol8-kiran-chavala","status":"Successfully Installed","size":920584192,"physicalsize":920584192,"domain":"ROOT","domainpath":"/","domainid":"f8f8593c-7730-11f0-9a5b-1e00900003a2","isextractable":false,"checksum":"107431c49aff924ec7abd78bfc120eaef8b37249724a50cd18fc7a1e3f93b78f45e4b4bc34deeb85e49c176aed2a96a751494d922f02b8fc944fba300ba49aaf","downloaddetails":[{"downloadState":"DOWNLOADED","datastore":"ref-trl-9219-k-Mol8-kiran-chavala-sec1","datastoreRole":"Image","downloadPercent":"100","datastoreId":"5b0e8553-41a1-43d6-ac58-836a349ffe03"}],"arch":"x86_64","bits":64,"isdynamicallyscalable":false,"directdownload":false,"url":"https://download.cloudstack.org/cks/setup-v1.33.1-calico-x86_64.iso","tags":[],"hasannotations":false},{"id":"d451da1f-5dc1-4828-a849-e0693959b16e","name":"d1","displaytext":"d1","ispublic":false,"isready":false,"passwordenabled":false,"format":"ISO","bootable":true,"isfeatured":false,"crossZones":true,"ostypeid":"300f8c51-7731-11f0-9a5b-1e00900003a2","ostypename":"AlmaLinux 8","account":"admin","zoneid":"5ae50b9f-6280-4c4b-9551-ee48da867034","zonename":"ref-trl-9219-k-Mol8-kiran-chavala","domain":"ROOT","domainpath":"/","domainid":"f8f8593c-7730-11f0-9a5b-1e00900003a2","isextractable":false,"downloaddetails":[],"arch":"x86_64","bits":64,"isdynamicallyscalable":false,"directdownload":false,"url":"http://10.0.3.130/isos/dummy.iso","tags":[],"hasannotations":false},{"id":"ec843a30-9ad3-4b97-9d46-13d83062b1b5","name":"d2","displaytext":"d2","ispublic":false,"isready":false,"passwordenabled":false,"format":"ISO","bootable":true,"isfeatured":false,"crossZones":true,"ostypeid":"300f8c51-7731-11f0-9a5b-1e00900003a2","ostypename":"AlmaLinux 8","account":"admin","zoneid":"5ae50b9f-6280-4c4b-9551-ee48da867034","zonename":"ref-trl-9219-k-Mol8-kiran-chavala","domain":"ROOT","domainpath":"/","domainid":"f8f8593c-7730-11f0-9a5b-1e00900003a2","isextractable":false,"downloaddetails":[],"arch":"x86_64","bits":64,"isdynamicallyscalable":false,"directdownload":false,"url":"http://10.0.3.130/isos/dummy.iso","tags":[],"hasannotations":false}]}}
(test) 🐱 > list isos id=
82393839-d239-434e-8745-0d24c0f58ee0 (v1.33.1-Kubernetes-Binaries-ISO)                     c2e22f89-98c1-4fcb-9d0b-362035a8db04 (vmware-tools.iso)                                    d451da1f-5dc1-4828-a849-e0693959b16e (d1)                                                  
d5cdaff5-bb7c-4a7f-967a-71af603e8da3 (vmware2-tools.iso)                                   ec843a30-9ad3-4b97-9d46-13d83062b1b5 (d2) 
```