### PR TITLE
autocomplete: allow searching configuration name

### DIFF
--- a/cli/completer.go
+++ b/cli/completer.go
@@ -28,6 +28,10 @@ import (
 	"github.com/apache/cloudstack-cloudmonkey/config"
 )
 
+var nameSupportingApis = []string{
+	"configuration",
+}
+
 func buildAPICacheMap(apiMap map[string][]*config.API) map[string][]*config.API {
 	for _, cmd := range cmd.AllCommands() {
 		verb := cmd.Name
@@ -237,8 +241,13 @@ func findAutocompleteAPI(arg *config.APIArg, apiFound *config.API, apiMap map[st
 			base = strings.TrimSuffix(argName, "id")
 		} else if strings.HasSuffix(argName, "ids") {
 			base = strings.TrimSuffix(argName, "ids")
-		} else if argName == "name" && strings.HasPrefix(apiFound.Noun, "configuration") {
-			base = "configuration"
+		} else if argName == "name" {
+			for _, noun := range nameSupportingApis {
+				if strings.HasPrefix(apiFound.Noun, noun) {
+					base = noun
+					break
+				}
+			}
 		}
 		// Handle common cases where base ends with a vowel and needs "es"
 		if strings.HasSuffix(base, "s") || strings.HasSuffix(base, "x") || strings.HasSuffix(base, "z") || strings.HasSuffix(base, "ch") || strings.HasSuffix(base, "sh") {

--- a/cli/completer.go
+++ b/cli/completer.go
@@ -232,14 +232,20 @@ func findAutocompleteAPI(arg *config.APIArg, apiFound *config.API, apiMap map[st
 	default:
 		// Heuristic: autocomplete for the arg for which a list<Arg without id/ids>s API exists
 		// For example, for zoneid arg, listZones API exists
-		cutIdx := len(argName)
+		base := argName
 		if strings.HasSuffix(argName, "id") {
-			cutIdx -= 2
+			base = strings.TrimSuffix(argName, "id")
 		} else if strings.HasSuffix(argName, "ids") {
-			cutIdx -= 3
-		} else {
+			base = strings.TrimSuffix(argName, "ids")
+		} else if argName == "name" && strings.HasPrefix(apiFound.Noun, "configuration") {
+			base = "configuration"
 		}
-		relatedNoun = argName[:cutIdx] + "s"
+		// Handle common cases where base ends with a vowel and needs "es"
+		if strings.HasSuffix(base, "s") || strings.HasSuffix(base, "x") || strings.HasSuffix(base, "z") || strings.HasSuffix(base, "ch") || strings.HasSuffix(base, "sh") {
+			relatedNoun = base + "es"
+		} else {
+			relatedNoun = base + "s"
+		}
 	}
 
 	config.Debug("Possible related noun for the arg: ", relatedNoun, " and type: ", arg.Type)


### PR DESCRIPTION
Allows searching name for configurations for all *configuration(s) APIs.

```
⇒  make run                                                                                                                                           allow-configname-autocomplete| 
▶  Running gofmt…
▶  Building executable… 1f24c66
▶  Done!
./bin/cmk
Apache CloudStack 🐵 CloudMonkey 6.4.0
Report issues: https://github.com/apache/cloudstack-cloudmonkey/issues

(test) 🐱 > update configuration name=allow.
allow.additional.vm.configuration.list.kvm (Allow additional vm configuration list kvm)                                                  allow.additional.vm.configuration.list.vmware (Allow additional vm configuration list vmware)                                            
allow.additional.vm.configuration.list.xenserver (Allow additional vm configuration list xenserver)                                      allow.admin.vm.on.disabled.resources (Allow admin vm on disabled resources)                                                              
allow.deploy.vm.if.deploy.on.given.host.fails (Allow deploy vm if deploy on given host fails)                                            allow.diskoffering.change.during.scale.vm (Allow diskoffering change during scale vm)                                                    
allow.domain.admins.to.create.tagged.offerings (Allow domain admins to create tagged offerings)                                          allow.duplicate.networkname (Allow duplicate networkname)                                                                                
allow.empty.start.end.ipaddress (Allow empty start end ipaddress)                                                                        allow.end.users.to.specify.vr.mtu (Allow end users to specify vr mtu)                                                                    
allow.list.metrics.computation (Allow list metrics computation)                                                                          allow.non.rfc1918.compliant.ips (Allow non rfc1918 compliant ips)                                                                        
allow.public.user.templates (Allow public user templates)                                                                                allow.router.on.disabled.resources (Allow router on disabled resources)                                                                  
allow.subdomain.network.access (Allow subdomain network access)                                                                          allow.user.create.projects (Allow user create projects)                                                                                  
allow.user.expunge.recover.vm (Allow user expunge recover vm)                                                                            allow.user.expunge.recover.volume (Allow user expunge recover volume)                                                                    
allow.user.force.stop.vm (Allow user force stop vm)                                                                                      allow.user.list.available.ips.on.shared.network (Allow user list available ips on shared network)                                        
allow.user.view.all.domain.accounts (Allow user view all domain accounts)                                                                allow.user.view.all.zones (Allow user view all zones)                                                                                    
allow.user.view.destroyed.vm (Allow user view destroyed VM) 
```