### PR TITLE
autocomplete: allow searching for VMs belonging to projects

### DIFF
--- a/cli/completer.go
+++ b/cli/completer.go
@@ -414,6 +414,9 @@ func (t *autoCompleter) Do(line []rune, pos int) (options [][]rune, offset int) 
 				if autocompleteAPI.Noun == "isos" {
 					autocompleteAPIArgs = append(autocompleteAPIArgs, "isofilter=executable")
 				}
+				if autocompleteAPI.Noun == "virtualmachines" {
+					autocompleteAPIArgs = append(autocompleteAPIArgs, "projectid=-1")
+				}
 
 				if apiFound.Name != "provisionCertificate" && autocompleteAPI.Name == "listHosts" {
 					autocompleteAPIArgs = append(autocompleteAPIArgs, "type=Routing")


### PR DESCRIPTION
Currently, when searching for VMs through the CloudMonkey's autocomplete, VMs belonging to projects are not listed. For instance, below are listed all existing VMs of the cloud environment:

```bash
(localcloud) 🌵 > list virtualmachines listall=true projectid=-1 filter=id,name,account,project
{
  "count": 4,
  "virtualmachine": [
    {
      "id": "2b7f0fe7-c114-4b01-93ab-dd31758b456a",
      "name": "project-1-vm-01",
      "project": "project-1"
    },
    {
      "id": "79c21a0f-1d5c-46b1-bd9b-691e09c8b7a5",
      "name": "project-1-vm-2",
      "project": "project-1"
    },
    {
      "account": "admin",
      "id": "f69735ac-2bc9-4847-a25f-fc21f27b6cb0",
      "name": "admin-vm-1"
    },
    {
      "account": "admin",
      "id": "bd29bd06-a186-4470-a1ec-8eb5cbec37c7",
      "name": "admin-vm-2"
    }
  ]
}
```

However, the projects' VMs are not listed as available options in the autocomplete.

<img width="541" height="90" alt="image" src="https://github.com/user-attachments/assets/23318564-5664-4497-8a1e-8ed0e5ff686a" />

<img width="536" height="83" alt="image" src="https://github.com/user-attachments/assets/ca35fba3-532d-4ae8-ac4e-acb9de341f27" />

---

This PR, therefore, adds the `projectid=-1` parameter to the `listVirtualMachines` API call that is performed by CloudMonkey when fetching the existing VMs. With that, it is possible to select VMs that belong to projects:

<img width="545" height="120" alt="image" src="https://github.com/user-attachments/assets/1f6b42ab-4bdf-4c38-ae33-578503469cb1" />

<img width="556" height="116" alt="image" src="https://github.com/user-attachments/assets/e942cb39-ea2c-44d8-a8c8-59b56cdc6294" />
