### PR TITLE
config: fix setting postrequest config

### DIFF
--- a/cmd/network.go
+++ b/cmd/network.go
@@ -411,9 +411,11 @@ func NewAPIRequest(r *Request, api string, args []string, isAsync bool) (map[str
 func executeRequest(r *Request, requestURL string, params url.Values) (*http.Response, error) {
 	config.SetupContext(r.Config)
 	if params.Has("password") || params.Has("userdata") || r.Config.Core.PostRequest {
-		requestURL = fmt.Sprintf("%s", r.Config.ActiveProfile.URL)
+		requestURL = r.Config.ActiveProfile.URL
+		config.Debug("Using HTTP POST for the request: ", requestURL)
 		return r.Client().PostForm(requestURL, params)
 	}
+	config.Debug("Using HTTP GET for the request: ", requestURL)
 	req, _ := http.NewRequestWithContext(*r.Config.Context, "GET", requestURL, nil)
 	return r.Client().Do(req)
 }

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -45,6 +45,7 @@ func init() {
 			"verifycert":   {"true", "false"},
 			"debug":        {"true", "false"},
 			"autocomplete": {"true", "false"},
+			"postrequest":  {"true", "false"},
 		},
 		Handle: func(r *Request) error {
 			if len(r.Args) < 1 {

--- a/config/config.go
+++ b/config/config.go
@@ -76,7 +76,7 @@ type Core struct {
 	VerifyCert   bool   `ini:"verifycert"`
 	ProfileName  string `ini:"profile"`
 	AutoComplete bool   `ini:"autocomplete"`
-	PostRequest  bool   `ini:postrequest`
+	PostRequest  bool   `ini:"postrequest"`
 }
 
 // Config describes CLI config file and default options
@@ -401,6 +401,8 @@ func (c *Config) UpdateConfig(key string, value string, update bool) {
 		}
 	case "autocomplete":
 		c.Core.AutoComplete = value == "true"
+	case "postrequest":
+		c.Core.PostRequest = value == "true"
 	default:
 		fmt.Println("Invalid option provided:", key)
 		return


### PR DESCRIPTION
PR #161 introduced `postrequest` config but there was no way to update that config other than updating the config file. This PR fixes the behaviour. Also adds a log to highlight what HTTP method is used.

Tested changing config;
```
⇒  make run                                                                                                                                                                                         
▶  Running gofmt…
▶  Building executable… 7510f73
▶  Done!
./bin/cmk
Apache CloudStack 🐵 CloudMonkey 6.5.0-rc
Report issues: https://github.com/apache/cloudstack-cloudmonkey/issues

(421-test) 🐱 > set profile postrequesttest
Loaded in-built API cache. Failed to read API cache, please run 'sync'.
Loaded server profile: postrequesttest
Url:         http://localhost:8080/client/api
Username:    admin
Domain:      /
API Key:     
Total APIs:  880

(postrequesttest) 🐱 > set url http://10.0.32.197:8080/client/api
Loaded in-built API cache. Failed to read API cache, please run 'sync'.
(postrequesttest) 🐱 > set debug true
[debug] UpdateConfig key:debug value:true update:true
[debug] Trying to read API cache from:/home/shwstppr/.cmk/profiles/postrequesttest.cache
Loaded in-built API cache. Failed to read API cache, please run 'sync'.
(postrequesttest) 🐱 > list zones filter=id,name
[debug] ExecLine line:list zones filter=id,name
[debug] ExecCmd args: list, zones, filter=id,name
[debug] Login POST URL:http://10.0.32.197:8080/client/apimap[command:[login] domain:[/] password:[password] response:[json] username:[admin]]
[debug] Login POST response status code:200
[debug] Login response body:{"loginresponse":{"username":"admin","userid":"9357510b-7e61-11f0-ba77-1e00c8000158","domainid":"430d0c02-7e61-11f0-ba77-1e00c8000158","timeout":1800,"account":"admin","firstname":"admin","lastname":"cloud","type":"1","timezone":"UTC","timezoneoffset":"0.0","registered":"false","sessionkey":"vBI44baeXU3Wpik2PLxZwRqcCsA","is2faenabled":"false","is2faverified":"true","issuerfor2fa":"CloudStack","managementserverid":"061c8be8-8efa-44f6-ade6-3c5502ce5b22"}}
[debug] Login sessionkey:vBI44baeXU3Wpik2PLxZwRqcCsA
[debug] Checking if 2FA is enabled and verified for the user map[account:admin domainid:430d0c02-7e61-11f0-ba77-1e00c8000158 firstname:admin is2faenabled:false is2faverified:true issuerfor2fa:CloudStack lastname:cloud managementserverid:061c8be8-8efa-44f6-ade6-3c5502ce5b22 registered:false sessionkey:vBI44baeXU3Wpik2PLxZwRqcCsA timeout:1800 timezone:UTC timezoneoffset:0.0 type:1 userid:9357510b-7e61-11f0-ba77-1e00c8000158 username:admin]
[debug] 2FA is not enabled for the user, skipping 2FA validation
[debug] NewAPIRequest API request URL:http://10.0.32.197:8080/client/api?command=listZones&expires=2025-08-26T09%3A25%3A04Z&filter=id%2Cname&response=json&sessionkey=vBI44baeXU3Wpik2PLxZwRqcCsA&signatureversion=3
[debug] Using HTTP POST for the request: http://10.0.32.197:8080/client/api
[debug] NewAPIRequest response status code:200
[debug] NewAPIRequest response body:{"listzonesresponse":{"count":1,"zone":[{"id":"ea7e88b7-0798-4ea7-adf3-253cf8b3d229","name":"ref-trl-9283-k-Mr8-abhishek-kumar","dns1":"10.0.32.1","dns2":"8.8.8.8","internaldns1":"10.0.32.1","internaldns2":"8.8.4.4","guestcidraddress":"10.1.1.0/24","networktype":"Advanced","securitygroupsenabled":false,"gputotal":0,"gpuused":0,"allocationstate":"Enabled","zonetoken":"891489eb-6f53-3e39-84d6-e97116312e88","dhcpprovider":"VirtualRouter","localstorageenabled":false,"tags":[],"allowuserspecifyvrmtu":false,"routerprivateinterfacemaxmtu":1500,"routerpublicinterfacemaxmtu":1500,"type":"Core","isnsxenabled":false,"ismultiarch":false,"asnrange":"","routedmodeenabled":true,"hasannotations":false}]}}
{
  "count": 1,
  "zone": [
    {
      "id": "ea7e88b7-0798-4ea7-adf3-253cf8b3d229",
      "name": "ref-trl-9283-k-Mr8-abhishek-kumar"
    }
  ]
}
(postrequesttest) 🐱 > set postrequest false
[debug] ExecLine line:set postrequest false
[debug] ExecCmd args: set, postrequest, false
[debug] Set command received:postrequest values:false
[debug] UpdateConfig key:postrequest value:false update:true
[debug] Trying to read API cache from:/home/shwstppr/.cmk/profiles/postrequesttest.cache
Loaded in-built API cache. Failed to read API cache, please run 'sync'.
(postrequesttest) 🐱 > list zones filter=id,name
[debug] ExecLine line:list zones filter=id,name
[debug] ExecCmd args: list, zones, filter=id,name
[debug] Login POST URL:http://10.0.32.197:8080/client/apimap[command:[login] domain:[/] password:[password] response:[json] username:[admin]]
[debug] Login POST response status code:200
[debug] Login response body:{"loginresponse":{"username":"admin","userid":"9357510b-7e61-11f0-ba77-1e00c8000158","domainid":"430d0c02-7e61-11f0-ba77-1e00c8000158","timeout":1800,"account":"admin","firstname":"admin","lastname":"cloud","type":"1","timezone":"UTC","timezoneoffset":"0.0","registered":"false","sessionkey":"8wnjcYpx7qzkjvlxLaDeHaZ7iLI","is2faenabled":"false","is2faverified":"true","issuerfor2fa":"CloudStack","managementserverid":"061c8be8-8efa-44f6-ade6-3c5502ce5b22"}}
[debug] Login sessionkey:8wnjcYpx7qzkjvlxLaDeHaZ7iLI
[debug] Checking if 2FA is enabled and verified for the user map[account:admin domainid:430d0c02-7e61-11f0-ba77-1e00c8000158 firstname:admin is2faenabled:false is2faverified:true issuerfor2fa:CloudStack lastname:cloud managementserverid:061c8be8-8efa-44f6-ade6-3c5502ce5b22 registered:false sessionkey:8wnjcYpx7qzkjvlxLaDeHaZ7iLI timeout:1800 timezone:UTC timezoneoffset:0.0 type:1 userid:9357510b-7e61-11f0-ba77-1e00c8000158 username:admin]
[debug] 2FA is not enabled for the user, skipping 2FA validation
[debug] NewAPIRequest API request URL:http://10.0.32.197:8080/client/api?command=listZones&expires=2025-08-26T09%3A25%3A40Z&filter=id%2Cname&response=json&sessionkey=8wnjcYpx7qzkjvlxLaDeHaZ7iLI&signatureversion=3
[debug] Using HTTP GET for the request: http://10.0.32.197:8080/client/api?command=listZones&expires=2025-08-26T09%3A25%3A40Z&filter=id%2Cname&response=json&sessionkey=8wnjcYpx7qzkjvlxLaDeHaZ7iLI&signatureversion=3
[debug] NewAPIRequest response status code:200
[debug] NewAPIRequest response body:{"listzonesresponse":{"count":1,"zone":[{"id":"ea7e88b7-0798-4ea7-adf3-253cf8b3d229","name":"ref-trl-9283-k-Mr8-abhishek-kumar","dns1":"10.0.32.1","dns2":"8.8.8.8","internaldns1":"10.0.32.1","internaldns2":"8.8.4.4","guestcidraddress":"10.1.1.0/24","networktype":"Advanced","securitygroupsenabled":false,"gputotal":0,"gpuused":0,"allocationstate":"Enabled","zonetoken":"891489eb-6f53-3e39-84d6-e97116312e88","dhcpprovider":"VirtualRouter","localstorageenabled":false,"tags":[],"allowuserspecifyvrmtu":false,"routerprivateinterfacemaxmtu":1500,"routerpublicinterfacemaxmtu":1500,"type":"Core","isnsxenabled":false,"ismultiarch":false,"asnrange":"","routedmodeenabled":true,"hasannotations":false}]}}
{
  "count": 1,
  "zone": [
    {
      "id": "ea7e88b7-0798-4ea7-adf3-253cf8b3d229",
      "name": "ref-trl-9283-k-Mr8-abhishek-kumar"
    }
  ]
}
(postrequesttest) 🐱 > set postrequest true
[debug] ExecLine line:set postrequest true
[debug] ExecCmd args: set, postrequest, true
[debug] Set command received:postrequest values:true
[debug] UpdateConfig key:postrequest value:true update:true
[debug] Trying to read API cache from:/home/shwstppr/.cmk/profiles/postrequesttest.cache
Loaded in-built API cache. Failed to read API cache, please run 'sync'.
(postrequesttest) 🐱 > list zones filter=id,name
[debug] ExecLine line:list zones filter=id,name
[debug] ExecCmd args: list, zones, filter=id,name
[debug] Login POST URL:http://10.0.32.197:8080/client/apimap[command:[login] domain:[/] password:[password] response:[json] username:[admin]]
[debug] Login POST response status code:200
[debug] Login response body:{"loginresponse":{"username":"admin","userid":"9357510b-7e61-11f0-ba77-1e00c8000158","domainid":"430d0c02-7e61-11f0-ba77-1e00c8000158","timeout":1800,"account":"admin","firstname":"admin","lastname":"cloud","type":"1","timezone":"UTC","timezoneoffset":"0.0","registered":"false","sessionkey":"RdGJhjn9r4MymvjBOTRio4hRqpg","is2faenabled":"false","is2faverified":"true","issuerfor2fa":"CloudStack","managementserverid":"061c8be8-8efa-44f6-ade6-3c5502ce5b22"}}
[debug] Login sessionkey:RdGJhjn9r4MymvjBOTRio4hRqpg
[debug] Checking if 2FA is enabled and verified for the user map[account:admin domainid:430d0c02-7e61-11f0-ba77-1e00c8000158 firstname:admin is2faenabled:false is2faverified:true issuerfor2fa:CloudStack lastname:cloud managementserverid:061c8be8-8efa-44f6-ade6-3c5502ce5b22 registered:false sessionkey:RdGJhjn9r4MymvjBOTRio4hRqpg timeout:1800 timezone:UTC timezoneoffset:0.0 type:1 userid:9357510b-7e61-11f0-ba77-1e00c8000158 username:admin]
[debug] 2FA is not enabled for the user, skipping 2FA validation
[debug] NewAPIRequest API request URL:http://10.0.32.197:8080/client/api?command=listZones&expires=2025-08-26T09%3A26%3A03Z&filter=id%2Cname&response=json&sessionkey=RdGJhjn9r4MymvjBOTRio4hRqpg&signatureversion=3
[debug] Using HTTP POST for the request: http://10.0.32.197:8080/client/api
[debug] NewAPIRequest response status code:200
[debug] NewAPIRequest response body:{"listzonesresponse":{"count":1,"zone":[{"id":"ea7e88b7-0798-4ea7-adf3-253cf8b3d229","name":"ref-trl-9283-k-Mr8-abhishek-kumar","dns1":"10.0.32.1","dns2":"8.8.8.8","internaldns1":"10.0.32.1","internaldns2":"8.8.4.4","guestcidraddress":"10.1.1.0/24","networktype":"Advanced","securitygroupsenabled":false,"gputotal":0,"gpuused":0,"allocationstate":"Enabled","zonetoken":"891489eb-6f53-3e39-84d6-e97116312e88","dhcpprovider":"VirtualRouter","localstorageenabled":false,"tags":[],"allowuserspecifyvrmtu":false,"routerprivateinterfacemaxmtu":1500,"routerpublicinterfacemaxmtu":1500,"type":"Core","isnsxenabled":false,"ismultiarch":false,"asnrange":"","routedmodeenabled":true,"hasannotations":false}]}}
{
  "count": 1,
  "zone": [
    {
      "id": "ea7e88b7-0798-4ea7-adf3-253cf8b3d229",
      "name": "ref-trl-9283-k-Mr8-abhishek-kumar"
    }
  ]
}
(postrequesttest) 🐱 > exit
[debug] ExecLine line:exit
[debug] ExecCmd args: exit
```