### PR TITLE
Fix auto-completion logic for APIs that end with 'y'

### DIFF
--- a/cli/completer.go
+++ b/cli/completer.go
@@ -221,7 +221,13 @@ func findAutocompleteAPI(arg *config.APIArg, apiFound *config.API, apiMap map[st
 		// Heuristic: user is trying to autocomplete for id/ids arg for a list API
 		relatedNoun = apiFound.Noun
 		if apiFound.Verb != "list" {
-			relatedNoun += "s"
+			config.Debug("relatedNoun before suffix check: ", relatedNoun)
+			if strings.HasSuffix(relatedNoun, "y") && len(relatedNoun) > 1 && !strings.ContainsAny(string(relatedNoun[len(relatedNoun)-2]), "aeiou") {
+				// Handle words ending in consonant + y (e.g., policy -> policies)
+				relatedNoun = relatedNoun[:len(relatedNoun)-1] + "ies"
+			} else if !strings.HasSuffix(relatedNoun, "ies") {
+				relatedNoun += "s"
+			}
 		}
 	case argName == "account":
 		// Heuristic: user is trying to autocomplete for accounts

--- a/cli/completer.go
+++ b/cli/completer.go
@@ -208,6 +208,22 @@ func findAPI(apiMap map[string][]*config.API, relatedNoun string) *config.API {
 	return autocompleteAPI
 }
 
+// pluralizeNoun applies simple English pluralization rules used by the
+// autocomplete heuristics below (e.g., policy -> policies, disk -> disks).
+func pluralizeNoun(noun string) string {
+	switch {
+	case strings.HasSuffix(noun, "ies"):
+		return noun
+	case strings.HasSuffix(noun, "y") && len(noun) > 1 && !strings.ContainsAny(string(noun[len(noun)-2]), "aeiou"):
+		// Handle words ending in consonant + y (e.g., policy -> policies)
+		return noun[:len(noun)-1] + "ies"
+	case strings.HasSuffix(noun, "s") || strings.HasSuffix(noun, "x") || strings.HasSuffix(noun, "z") || strings.HasSuffix(noun, "ch") || strings.HasSuffix(noun, "sh"):
+		return noun + "es"
+	default:
+		return noun + "s"
+	}
+}
+
 func findAutocompleteAPI(arg *config.APIArg, apiFound *config.API, apiMap map[string][]*config.API) *config.API {
 	if arg.Type == "map" {
 		return nil
@@ -221,13 +237,7 @@ func findAutocompleteAPI(arg *config.APIArg, apiFound *config.API, apiMap map[st
 		// Heuristic: user is trying to autocomplete for id/ids arg for a list API
 		relatedNoun = apiFound.Noun
 		if apiFound.Verb != "list" {
-			config.Debug("relatedNoun before suffix check: ", relatedNoun)
-			if strings.HasSuffix(relatedNoun, "y") && len(relatedNoun) > 1 && !strings.ContainsAny(string(relatedNoun[len(relatedNoun)-2]), "aeiou") {
-				// Handle words ending in consonant + y (e.g., policy -> policies)
-				relatedNoun = relatedNoun[:len(relatedNoun)-1] + "ies"
-			} else if !strings.HasSuffix(relatedNoun, "ies") {
-				relatedNoun += "s"
-			}
+			relatedNoun = pluralizeNoun(relatedNoun)
 		}
 	case argName == "account":
 		// Heuristic: user is trying to autocomplete for accounts
@@ -255,12 +265,7 @@ func findAutocompleteAPI(arg *config.APIArg, apiFound *config.API, apiMap map[st
 				}
 			}
 		}
-		// Handle common cases where base ends with a vowel and needs "es"
-		if strings.HasSuffix(base, "s") || strings.HasSuffix(base, "x") || strings.HasSuffix(base, "z") || strings.HasSuffix(base, "ch") || strings.HasSuffix(base, "sh") {
-			relatedNoun = base + "es"
-		} else {
-			relatedNoun = base + "s"
-		}
+		relatedNoun = pluralizeNoun(base)
 	}
 
 	config.Debug("Possible related noun for the arg: ", relatedNoun, " and type: ", arg.Type)

--- a/cli/completer.go
+++ b/cli/completer.go
@@ -236,7 +236,8 @@ func findAutocompleteAPI(arg *config.APIArg, apiFound *config.API, apiMap map[st
 	case argName == "id" || argName == "ids":
 		// Heuristic: user is trying to autocomplete for id/ids arg for a list API
 		relatedNoun = apiFound.Noun
-		if apiFound.Verb != "list" {
+		if apiFound.Verb != "list" && findAPI(apiMap, relatedNoun) == nil {
+			// Noun may already be plural (e.g. bulk ops like deleteAlerts)
 			relatedNoun = pluralizeNoun(relatedNoun)
 		}
 	case argName == "account":


### PR DESCRIPTION
With this fix, autocompletion works for APIs ending in 'y' or 'ies' e.g. deleteSnapshotPolicies , deleteAutoscalePolicy

<img width="1148" height="279" alt="Screenshot from 2025-09-02 15-00-22" src="https://github.com/user-attachments/assets/9bc2cf8a-73ca-4ee3-a79e-fa6c097ac494" />
<img width="1920" height="369" alt="Screenshot from 2025-09-02 15-01-03" src="https://github.com/user-attachments/assets/a97fc2b0-4f9b-4c24-a763-6fc35c4ef653" />
