### PR TITLE
ci: fix marvin install failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
         run: |
           mvn -q -Pdeveloper -pl developer -Ddeploydb
           mvn -q -Pdeveloper -pl developer -Ddeploydb-simulator
-          python3 -m pip install --user --upgrade tools/marvin/dist/Marvin-*.tar.gz
+          python3 -m pip install --user --upgrade tools/marvin/dist/[mM]arvin-*.tar.gz
 
       - name: Start CloudStack mgmt (Jetty) in background
         id: start_ms


### PR DESCRIPTION
Archive is named differently for different CloudStack version.