### PR TITLE
 Autocomplete: suggestions for internetprotocol enum values

### DIFF
--- a/cli/completer.go
+++ b/cli/completer.go
@@ -107,6 +107,13 @@ func inArray(s string, array []string) bool {
 func lastString(array []string) string {
 	return array[len(array)-1]
 }
+func enumAutocomplete(argName string) []string {
+	switch argName {
+	case "internetprotocol":
+		return []string{"ipv4", "dualstack"}
+	}
+	return nil
+}
 
 type argOption struct {
 	Value  string
@@ -412,7 +419,18 @@ func (t *autoCompleter) Do(line []rune, pos int) (options [][]rune, offset int) 
 				}
 				return
 			}
-
+			argName := strings.Replace(arg.Name, "=", "", -1)
+			enumValues := enumAutocomplete(argName)
+			if enumValues != nil {
+				offset = 0
+				for _, val := range enumValues {
+					if strings.HasPrefix(val, argInput) {
+						options = append(options, []rune(val[len(argInput):]+" "))
+						offset = len(argInput)
+					}
+				}
+				return
+			}
 			autocompleteAPI := findAutocompleteAPI(arg, apiFound, apiMap)
 			if autocompleteAPI == nil {
 				return nil, 0


### PR DESCRIPTION
### Enhancement for

The internetprotocol parameter of the createVPCOffering API supports the values:

```
ipv4
dualstack
```

However, CloudMonkey does not currently provide autocomplete suggestions for these values. When users type:

`create vpcoffering internetprotocol=
`
no suggestions are returned.

### Solution

Add enum-based autocomplete support for the internetprotocol parameter in cli/completer.go. The change introduces a small helper to provide enum values and integrates it into the existing autocomplete flow.

After this change, CloudMonkey suggests:
<img width="1218" height="87" alt="Screenshot from 2026-03-08 15-51-40" src="https://github.com/user-attachments/assets/d3ecf4f1-8e25-4fea-9c39-1e54e1636dee" />


```
ipv4
dualstack

```
when completing the internetprotocol parameter.

### Testing

Manually verified that:

`create vpcoffering internetprotocol=<TAB>`

suggests ipv4 and dualstack, and existing autocomplete functionality remains unaffected.