### PR TITLE
Fix filter=count output to avoid empty objects

### DIFF
--- a/cmd/output.go
+++ b/cmd/output.go
@@ -278,8 +278,19 @@ func filterResponse(response map[string]interface{}, filter []string, excludeFil
 					}
 				}
 
+				// Skip completely empty rows after filtering
+				if len(filteredRow) == 0 {
+					continue
+				}
+
 				filteredRows = append(filteredRows, filteredRow)
 			}
+
+			// If no non-empty rows remain for this key, omit the key entirely
+			if len(filteredRows) == 0 {
+				continue
+			}
+
 			if originalKind == reflect.Map && len(filteredRows) > 0 {
 				filteredResponse[key] = filteredRows[0]
 			} else {


### PR DESCRIPTION
Fixes #197 where using filter=count resulted in empty objects being printed in list responses.

### Problem
When `filter=count` is applied, CloudMonkey still iterates over list items and prints empty `{}` entries, even when the filtered field does not exist in those list objects.

### Fix
- Skip empty rows after filtering.
- Omit list fields when no valid entries remain after applying the filter.
- Preserve only relevant top-level fields (for example, `"count"`).

### Result
Before, a command such as:

```bash
(localcloud) > list usagerecords startdate=2025-10-07 enddate=2025-10-10 type=6 usageid=2c218702-abff-46e8-bc8a-3e12fffa2188 filter=count
```

could return:

```json
{
  "count": 319,
  "usagerecord": [
    {},
    {},
    ...
    {}
  ]
}
```

Now the output correctly returns only the top-level count field:

```json
{
  "count": 319
}
```

instead of including empty objects.