### PR TITLE
Use Related metadata for autocomplete API discovery

### DIFF
--- a/cli/completer.go
+++ b/cli/completer.go
@@ -214,29 +214,33 @@ func findAutocompleteAPI(arg *config.APIArg, apiFound *config.API, apiMap map[st
 	}
 
 	var autocompleteAPI *config.API
+
 	argName := strings.Replace(arg.Name, "=", "", -1)
-	relatedNoun := argName
+
+	// Build the noun we expect from the existing heuristic rules.
+	expectedNoun := argName
 	switch {
 	case argName == "id" || argName == "ids":
-		// Heuristic: user is trying to autocomplete for id/ids arg for a list API
-		relatedNoun = apiFound.Noun
+		expectedNoun = apiFound.Noun
 		if apiFound.Verb != "list" {
-			relatedNoun += "s"
+			expectedNoun += "s"
 		}
+
 	case argName == "account":
-		// Heuristic: user is trying to autocomplete for accounts
-		relatedNoun = "accounts"
+		expectedNoun = "accounts"
+
 	case argName == "ipaddressid":
-		// Heuristic: user is trying to autocomplete for ip addresses
-		relatedNoun = "publicipaddresses"
+		expectedNoun = "publicipaddresses"
+
 	case argName == "storageid":
-		relatedNoun = "storagepools"
+		expectedNoun = "storagepools"
+
 	case argName == "associatednetworkid":
-		relatedNoun = "networks"
+		expectedNoun = "networks"
+
 	default:
-		// Heuristic: autocomplete for the arg for which a list<Arg without id/ids>s API exists
-		// For example, for zoneid arg, listZones API exists
 		base := argName
+
 		if strings.HasSuffix(argName, "id") {
 			base = strings.TrimSuffix(argName, "id")
 		} else if strings.HasSuffix(argName, "ids") {
@@ -249,15 +253,61 @@ func findAutocompleteAPI(arg *config.APIArg, apiFound *config.API, apiMap map[st
 				}
 			}
 		}
-		// Handle common cases where base ends with a vowel and needs "es"
-		if strings.HasSuffix(base, "s") || strings.HasSuffix(base, "x") || strings.HasSuffix(base, "z") || strings.HasSuffix(base, "ch") || strings.HasSuffix(base, "sh") {
-			relatedNoun = base + "es"
+
+		if strings.HasSuffix(base, "s") ||
+			strings.HasSuffix(base, "x") ||
+			strings.HasSuffix(base, "z") ||
+			strings.HasSuffix(base, "ch") ||
+			strings.HasSuffix(base, "sh") {
+			expectedNoun = base + "es"
 		} else {
-			relatedNoun = base + "s"
+			expectedNoun = base + "s"
 		}
 	}
 
+	// FIRST: prefer Related APIs whose noun matches the expected noun.
+	for _, relatedAPI := range arg.Related {
+		if !strings.HasPrefix(strings.ToLower(relatedAPI), "list") {
+			continue
+		}
+
+		for _, listAPI := range apiMap["list"] {
+			if strings.EqualFold(listAPI.Name, relatedAPI) &&
+				strings.EqualFold(listAPI.Noun, expectedNoun) {
+
+				config.Debug(
+					"Autocomplete: API found using Related metadata: ",
+					listAPI.Name,
+				)
+
+				return listAPI
+			}
+		}
+	}
+
+	// SECOND: fallback to any list API from Related.
+	for _, relatedAPI := range arg.Related {
+		if !strings.HasPrefix(strings.ToLower(relatedAPI), "list") {
+			continue
+		}
+
+		for _, listAPI := range apiMap["list"] {
+			if strings.EqualFold(listAPI.Name, relatedAPI) {
+
+				config.Debug(
+					"Autocomplete: API found using Related metadata fallback: ",
+					listAPI.Name,
+				)
+
+				return listAPI
+			}
+		}
+	}
+
+	relatedNoun := expectedNoun
+
 	config.Debug("Possible related noun for the arg: ", relatedNoun, " and type: ", arg.Type)
+
 	autocompleteAPI = findAPI(apiMap, relatedNoun)
 
 	if autocompleteAPI == nil {
@@ -278,13 +328,16 @@ func findAutocompleteAPI(arg *config.APIArg, apiFound *config.API, apiMap map[st
 	// Heuristic: find any list API that contains the arg name
 	if autocompleteAPI == nil {
 		config.Debug("Finding possible API that have: ", argName, " related APIs: ", arg.Related)
+
 		possibleAPIs := []*config.API{}
+
 		for _, listAPI := range apiMap["list"] {
 			if strings.Contains(listAPI.Noun, argName) {
 				config.Debug("Found possible API: ", listAPI.Name)
 				possibleAPIs = append(possibleAPIs, listAPI)
 			}
 		}
+
 		if len(possibleAPIs) == 1 {
 			autocompleteAPI = possibleAPIs[0]
 		}

--- a/cli/completer.go
+++ b/cli/completer.go
@@ -269,33 +269,6 @@ func findAutocompleteAPI(arg *config.APIArg, apiFound *config.API, apiMap map[st
 		relatedNoun = pluralizeNoun(base)
 	}
 
-	// Prefer authoritative Related metadata: a list API whose noun matches
-	// the related noun derived above.
-	for _, relatedAPI := range arg.Related {
-		if !strings.HasPrefix(strings.ToLower(relatedAPI), "list") {
-			continue
-		}
-		for _, listAPI := range apiMap["list"] {
-			if strings.EqualFold(listAPI.Name, relatedAPI) && strings.EqualFold(listAPI.Noun, relatedNoun) {
-				config.Debug("Autocomplete: API found using Related metadata: ", listAPI.Name)
-				return listAPI
-			}
-		}
-	}
-
-	// Fall back to any list API named in the Related metadata.
-	for _, relatedAPI := range arg.Related {
-		if !strings.HasPrefix(strings.ToLower(relatedAPI), "list") {
-			continue
-		}
-		for _, listAPI := range apiMap["list"] {
-			if strings.EqualFold(listAPI.Name, relatedAPI) {
-				config.Debug("Autocomplete: API found using Related metadata fallback: ", listAPI.Name)
-				return listAPI
-			}
-		}
-	}
-
 	config.Debug("Possible related noun for the arg: ", relatedNoun, " and type: ", arg.Type)
 	autocompleteAPI = findAPI(apiMap, relatedNoun)
 
@@ -312,6 +285,22 @@ func findAutocompleteAPI(arg *config.APIArg, apiFound *config.API, apiMap map[st
 
 	if strings.HasSuffix(relatedNoun, "s") {
 		relatedNoun = relatedNoun[:len(relatedNoun)-1]
+	}
+
+	// Prefer the API's own Related metadata when the noun heuristics found
+	// nothing, so entity-reference args still get completions.
+	if autocompleteAPI == nil {
+		for _, relatedAPI := range arg.Related {
+			if !strings.HasPrefix(strings.ToLower(relatedAPI), "list") {
+				continue
+			}
+			for _, listAPI := range apiMap["list"] {
+				if strings.EqualFold(listAPI.Name, relatedAPI) {
+					config.Debug("Autocomplete: API found using Related metadata: ", listAPI.Name)
+					return listAPI
+				}
+			}
+		}
 	}
 
 	// Heuristic: find any list API that contains the arg name

--- a/cli/completer.go
+++ b/cli/completer.go
@@ -269,6 +269,33 @@ func findAutocompleteAPI(arg *config.APIArg, apiFound *config.API, apiMap map[st
 		relatedNoun = pluralizeNoun(base)
 	}
 
+	// Prefer authoritative Related metadata: a list API whose noun matches
+	// the related noun derived above.
+	for _, relatedAPI := range arg.Related {
+		if !strings.HasPrefix(strings.ToLower(relatedAPI), "list") {
+			continue
+		}
+		for _, listAPI := range apiMap["list"] {
+			if strings.EqualFold(listAPI.Name, relatedAPI) && strings.EqualFold(listAPI.Noun, relatedNoun) {
+				config.Debug("Autocomplete: API found using Related metadata: ", listAPI.Name)
+				return listAPI
+			}
+		}
+	}
+
+	// Fall back to any list API named in the Related metadata.
+	for _, relatedAPI := range arg.Related {
+		if !strings.HasPrefix(strings.ToLower(relatedAPI), "list") {
+			continue
+		}
+		for _, listAPI := range apiMap["list"] {
+			if strings.EqualFold(listAPI.Name, relatedAPI) {
+				config.Debug("Autocomplete: API found using Related metadata fallback: ", listAPI.Name)
+				return listAPI
+			}
+		}
+	}
+
 	config.Debug("Possible related noun for the arg: ", relatedNoun, " and type: ", arg.Type)
 	autocompleteAPI = findAPI(apiMap, relatedNoun)
 

--- a/cli/completer_test.go
+++ b/cli/completer_test.go
@@ -1,0 +1,165 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/apache/cloudstack-cloudmonkey/config"
+)
+
+func TestFindAutocompleteAPIRelatedNounMatch(t *testing.T) {
+	arg := &config.APIArg{
+		Name: "domainid=",
+		Related: []string{
+			"createDomain",
+			"listDomains",
+			"updateDomain",
+		},
+	}
+
+	apiFound := &config.API{
+		Name: "listVirtualMachines",
+		Verb: "list",
+		Noun: "virtualmachines",
+	}
+
+	apiMap := map[string][]*config.API{
+		"list": {
+			{
+				Name: "listDomains",
+				Noun: "domains",
+			},
+		},
+	}
+
+	result := findAutocompleteAPI(arg, apiFound, apiMap)
+
+	if result == nil {
+		t.Fatal("expected API, got nil")
+	}
+
+	if result.Name != "listDomains" {
+		t.Fatalf("expected listDomains, got %s", result.Name)
+	}
+}
+
+func TestFindAutocompleteAPIRelatedFallback(t *testing.T) {
+	arg := &config.APIArg{
+		Name: "domainid=",
+		Related: []string{
+			"listDomainChildren",
+		},
+	}
+
+	apiFound := &config.API{
+		Name: "listVirtualMachines",
+		Verb: "list",
+		Noun: "virtualmachines",
+	}
+
+	apiMap := map[string][]*config.API{
+		"list": {
+			{
+				Name: "listDomainChildren",
+				Noun: "domainchildren",
+			},
+		},
+	}
+
+	result := findAutocompleteAPI(arg, apiFound, apiMap)
+
+	if result == nil {
+		t.Fatal("expected API, got nil")
+	}
+
+	if result.Name != "listDomainChildren" {
+		t.Fatalf("expected listDomainChildren, got %s", result.Name)
+	}
+}
+
+func TestFindAutocompleteAPIEmptyRelatedFallsBackToHeuristic(t *testing.T) {
+	arg := &config.APIArg{
+		Name: "zoneid=",
+	}
+
+	apiFound := &config.API{
+		Name: "listVirtualMachines",
+		Verb: "list",
+		Noun: "virtualmachines",
+	}
+
+	apiMap := map[string][]*config.API{
+		"list": {
+			{
+				Name: "listZones",
+				Noun: "zones",
+			},
+		},
+	}
+
+	result := findAutocompleteAPI(arg, apiFound, apiMap)
+
+	if result == nil {
+		t.Fatal("expected API, got nil")
+	}
+
+	if result.Name != "listZones" {
+		t.Fatalf("expected listZones, got %s", result.Name)
+	}
+}
+
+func TestFindAutocompleteAPINonListRelatedFallsBackToHeuristic(t *testing.T) {
+	arg := &config.APIArg{
+		Name: "zoneid=",
+		Related: []string{
+			"createZone",
+			"updateZone",
+		},
+	}
+
+	apiFound := &config.API{
+		Name: "listVirtualMachines",
+		Verb: "list",
+		Noun: "virtualmachines",
+	}
+
+	apiMap := map[string][]*config.API{
+		"list": {
+			{
+				Name: "listZones",
+				Noun: "zones",
+			},
+		},
+	}
+
+	result := findAutocompleteAPI(arg, apiFound, apiMap)
+
+	if result == nil {
+		t.Fatal("expected API, got nil")
+	}
+
+	if result.Name != "listZones" {
+		t.Fatalf("expected listZones, got %s", result.Name)
+	}
+}
+
+func TestFindAutocompleteAPIMapTypeReturnsNil(t *testing.T) {
+	arg := &config.APIArg{
+		Type: "map",
+	}
+
+	apiFound := &config.API{
+		Name: "listVirtualMachines",
+		Verb: "list",
+		Noun: "virtualmachines",
+	}
+
+	apiMap := map[string][]*config.API{
+		"list": {},
+	}
+
+	result := findAutocompleteAPI(arg, apiFound, apiMap)
+
+	if result != nil {
+		t.Fatalf("expected nil, got %v", result)
+	}
+}

--- a/cli/completer_test.go
+++ b/cli/completer_test.go
@@ -163,3 +163,44 @@ func TestFindAutocompleteAPIMapTypeReturnsNil(t *testing.T) {
 		t.Fatalf("expected nil, got %v", result)
 	}
 }
+
+func TestFindAutocompleteAPIHeuristicWinsOverRelated(t *testing.T) {
+	// registerIso's projectid arg lists many related APIs; the noun heuristic
+	// must keep winning so the completion stays listProjects.
+	arg := &config.APIArg{
+		Name: "projectid=",
+		Related: []string{
+			"listProjectAccounts",
+			"listProjects",
+		},
+	}
+
+	apiFound := &config.API{
+		Name: "registerIso",
+		Verb: "register",
+		Noun: "iso",
+	}
+
+	apiMap := map[string][]*config.API{
+		"list": {
+			{
+				Name: "listProjectAccounts",
+				Noun: "projectaccounts",
+			},
+			{
+				Name: "listProjects",
+				Noun: "projects",
+			},
+		},
+	}
+
+	result := findAutocompleteAPI(arg, apiFound, apiMap)
+
+	if result == nil {
+		t.Fatal("expected API, got nil")
+	}
+
+	if result.Name != "listProjects" {
+		t.Fatalf("expected listProjects, got %s", result.Name)
+	}
+}


### PR DESCRIPTION
Summary

Fixes apache/cloudstack#10442

CloudMonkey already parses and stores the Related metadata exposed by CloudStack APIs in `APIArg.Related`, but `findAutocompleteAPI()` did not use this information during autocomplete API discovery.

This change updates autocomplete API selection to prefer authoritative Related metadata before falling back to the existing heuristic-based lookup logic. This improves reliability for entity-reference parameter completion while preserving backward compatibility with the current behavior.

Changes

* Use `APIArg.Related` when selecting the autocomplete lookup API.
* Prefer Related APIs whose noun matches the expected resource noun.
* Fall back to any valid Related `list*` API if no noun match is found.
* Preserve all existing heuristic-based lookup logic as a fallback.
* Add unit test coverage for Related-based autocomplete API discovery.

Validation

Verified runtime behavior for common entity-reference parameters:

* `zoneid` → `listZones`
* `domainid` → `listDomains`
* `networkid` → `listNetworks`

Added unit tests covering:

* Related noun match selection.
* Related API fallback selection.
* Empty Related metadata fallback to existing heuristics.
* Non-list Related metadata fallback to existing heuristics.
* Map-type argument handling.

Build and validation:

```bash
go fmt ./...
go test ./...
go build -o bin/cmk .
```

Test results:

```text
ok github.com/apache/cloudstack-cloudmonkey/cli
```
