### PR TITLE
Add the ASF licence header to cli/completer_test.go

### DIFF
--- a/cli/completer_test.go
+++ b/cli/completer_test.go
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package cli
 
 import (


### PR DESCRIPTION
### Problem

The Apache RAT check has been failing on `main` since 9a04d5b (the #214 merge):

```
! Unapproved:         1    A count of unapproved licenses.
! /cli/completer_test.go
```

`cli/completer_test.go` landed in #214 without the ASF licence header, so RAT counts it as unapproved and the workflow's `Unapproved: 0` gate fails.

### Fix

Add the standard 16-line ASF header, the same one every other `.go` file in the repo carries.

### Testing

Ran the exact command from `.github/workflows/rat.yaml` locally with Apache RAT 0.18:

```
java -jar apache-rat-0.18/apache-rat-0.18.jar -d . -E .rat-excludes
```

- Before: `Unapproved: 1` — `/cli/completer_test.go`
- After: `Unapproved: 0`

Also `gofmt` clean, `go build ./...` OK, `go test ./...` passes.