### PR TITLE
bump version 6.6.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,21 @@
 Apache CloudStack CloudMonkey Changelog
 ---------------------------------------
 
+Version 6.6.0
+=============
+This release includes:
+- Adds support for API request signing with HmacSHA512
+- Adds a switch command to change the active server profile from the shell
+- Adds support for configuring cmk through environment variables in addition to arguments
+- Adds autocompletion for virtual machines that belong to projects
+- Uses the Related metadata exposed by API discovery to pick the right list API for autocompletion
+- Fixes autocompletion for APIs whose noun ends in 'y', such as snapshot policies
+- Fixes a slice bounds panic in autocompletion
+- Fixes a nil pointer panic on sync when the management server returns an empty API list
+- Fixes filter=count output to avoid emitting empty objects
+- Switches to the maintained ergochat/readline library for the interactive shell
+- Improves repository automation, licence auditing and security documentation
+
 Version 6.5.0
 =============
 This release includes:

--- a/config/about.go
+++ b/config/about.go
@@ -26,7 +26,7 @@ func (c *Config) Name() string {
 
 // Version CLI
 func (c *Config) Version() string {
-	return "6.6.0-SNAPSHOT"
+	return "6.6.0"
 }
 
 // PrintHeader prints startup message in CLI mode

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: cloudmonkey
 # define the tag anchor on the allowed 'version' field
-version: &release_tag 6.5.0
+version: &release_tag 6.6.0
 summary: Apache CloudStack CLI
 description: |
   A CLI and interactive shell that simplifies configuration and management of


### PR DESCRIPTION
Prepares the tree for the 6.6.0 release (step 2.2 of the release process).

### Changes

| File | From | To |
|---|---|---|
| `config/about.go` | `6.6.0-SNAPSHOT` | `6.6.0` |
| `snap/snapcraft.yaml` | `version: &release_tag 6.5.0` | `6.6.0` |
| `CHANGES.md` | — | new `Version 6.6.0` section |

The snapcraft anchor is reused by `source-tag` and `CMK_TAG`, so the single edit on line 3 updates all three.

### Changelog entry

Drawn from the 25 commits since the `6.5.0` tag. Please correct the wording if anything reads wrong.

```
Version 6.6.0
=============
This release includes:
- Adds support for API request signing with HmacSHA512
- Adds a switch command to change the active server profile from the shell
- Adds support for configuring cmk through environment variables in addition to arguments
- Adds autocompletion for virtual machines that belong to projects
- Uses the Related metadata exposed by API discovery to pick the right list API for autocompletion
- Fixes autocompletion for APIs whose noun ends in 'y', such as snapshot policies
- Fixes a slice bounds panic in autocompletion
- Fixes a nil pointer panic on sync when the management server returns an empty API list
- Fixes filter=count output to avoid emitting empty objects
- Switches to the maintained ergochat/readline library for the interactive shell
- Improves repository automation, licence auditing and security documentation
```

### Testing

- `gofmt` clean, `go build ./...` OK, `go test ./...` passes
- `snap/snapcraft.yaml` parses; `version` and `source-tag` both resolve to `6.6.0`
- `make all && ./bin/cmk version` reports `Apache CloudStack 🐵 CloudMonkey 6.6.0`