### PR TITLE
Fix version parameter autocompletion

### DIFF
--- a/cli/completer.go
+++ b/cli/completer.go
@@ -113,7 +113,7 @@ type argOption struct {
 	Detail string
 }
 
-func buildArgOptions(response map[string]interface{}, hasID bool) []argOption {
+func buildArgOptions(response map[string]interface{}, hasID bool, valueField string) []argOption {
 	argOptions := []argOption{}
 	for _, v := range response {
 		switch obj := v.(type) {
@@ -164,9 +164,18 @@ func buildArgOptions(response map[string]interface{}, hasID bool) []argOption {
 						opt.Detail = detail
 					}
 				} else {
-					opt.Value = name
+					if valueField != "" {
+						if value, ok := resource[valueField].(string); ok {
+							opt.Value = value
+						}
+					}
+
+					if len(opt.Value) == 0 {
+						opt.Value = name
+					}
+
 					opt.Detail = detail
-					if len(name) == 0 {
+					if len(opt.Value) == 0 {
 						opt.Value = detail
 					}
 				}
@@ -227,6 +236,14 @@ func pluralizeNoun(noun string) string {
 func findAutocompleteAPI(arg *config.APIArg, apiFound *config.API, apiMap map[string][]*config.API) *config.API {
 	if arg.Type == "map" {
 		return nil
+	}
+
+	if apiFound.Verb == "list" && strings.TrimSuffix(arg.Name, "=") == "version" {
+		for _, responseKey := range apiFound.ResponseKeys {
+			if responseKey == "version" {
+				return apiFound
+			}
+		}
 	}
 
 	var autocompleteAPI *config.API
@@ -479,7 +496,12 @@ func (t *autoCompleter) Do(line []rune, pos int) (options [][]rune, offset int) 
 				t.Config.StopSpinner(spinner)
 
 				hasID := strings.HasSuffix(arg.Name, "id=") || strings.HasSuffix(arg.Name, "ids=") || autocompleteAPI.Name == "listUsageTypes"
-				argOptions = buildArgOptions(response, hasID)
+				valueField := ""
+				if apiFound == autocompleteAPI {
+					valueField = strings.TrimSuffix(arg.Name, "=")
+				}
+
+				argOptions = buildArgOptions(response, hasID, valueField)
 			}
 
 			filteredOptions := []argOption{}

--- a/cli/completer_test.go
+++ b/cli/completer_test.go
@@ -221,3 +221,81 @@ func TestFindAutocompleteAPIHeuristicWinsOverRelated(t *testing.T) {
 		t.Fatalf("expected listProjects, got %s", result.Name)
 	}
 }
+
+func TestFindAutocompleteAPIVersionUsesCurrentListAPI(t *testing.T) {
+	tests := []struct {
+		name     string
+		apiFound *config.API
+	}{
+		{
+			name: "listHosts",
+			apiFound: &config.API{
+				Name: "listHosts",
+				Verb: "list",
+				Noun: "hosts",
+				ResponseKeys: []string{
+					"id",
+					"name",
+					"version",
+				},
+			},
+		},
+		{
+			name: "listRouters",
+			apiFound: &config.API{
+				Name: "listRouters",
+				Verb: "list",
+				Noun: "routers",
+				ResponseKeys: []string{
+					"name",
+					"version",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			arg := &config.APIArg{
+				Name: "version=",
+			}
+
+			apiMap := map[string][]*config.API{
+				"list": {
+					{
+						Name: "listKubernetesSupportedVersions",
+						Noun: "kubernetessupportedversions",
+					},
+				},
+			}
+
+			result := findAutocompleteAPI(arg, tt.apiFound, apiMap)
+
+			if result != tt.apiFound {
+				t.Fatalf("expected %s, got %v", tt.apiFound.Name, result)
+			}
+		})
+	}
+}
+
+func TestBuildArgOptionsUsesValueField(t *testing.T) {
+	response := map[string]interface{}{
+		"host": []interface{}{
+			map[string]interface{}{
+				"id":      "host-id",
+				"name":    "nvs-kvm01",
+				"version": "4.22.1.0",
+			},
+		},
+	}
+
+	options := buildArgOptions(response, false, "version")
+
+	if len(options) != 1 {
+		t.Fatalf("expected 1 option, got %d", len(options))
+	}
+
+	if options[0].Value != "4.22.1.0" {
+		t.Fatalf("expected 4.22.1.0, got %s", options[0].Value)
+	}
+}


### PR DESCRIPTION
Fixes #224

The version parameter autocompletion was incorrectly retrieving
registered Kubernetes versions for APIs such as list hosts and
list routers.

This change makes version completion use the current list API's
version response field when available.

Added regression tests for listHosts and listRouters.

Verified with:
- go test ./...
- go vet ./...
- make
- git diff --check